### PR TITLE
build: fix yarn lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "diff": "lerna run diff --",
     "test": "backstage-cli test",
     "test:all": "lerna run test -- --coverage",
-    "lint": "backstage-cli repo lint --since origin/master",
+    "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "create-plugin": "backstage-cli create-plugin --scope internal",


### PR DESCRIPTION
Fixes yarn lint in the example backstage application to use the main branch when determining the changes to lint.