### PR TITLE
feat: create new revisions of a package

### DIFF
--- a/plugins/cad/src/types/PackageRevision.ts
+++ b/plugins/cad/src/types/PackageRevision.ts
@@ -48,6 +48,7 @@ export type PackageRevisionTask = {
   type: string;
   init?: PackageRevisionTaskInit;
   clone?: PackageRevisionTaskClone;
+  edit?: PackageRevisionTaskEdit;
   eval?: PackageRevisionTaskEval;
 };
 
@@ -62,10 +63,14 @@ export type PackageRevisionTaskClone = {
 };
 
 export type PackageRevisionTaskCloneUpstreamRef = {
-  upstreamRef: PackageRevisionTaskCloneUpstreamRefNamedRepository;
+  upstreamRef: PackageRevisionTaskNamedRepository;
 };
 
-export type PackageRevisionTaskCloneUpstreamRefNamedRepository = {
+export type PackageRevisionTaskEdit = {
+  sourceRef: PackageRevisionTaskNamedRepository;
+};
+
+export type PackageRevisionTaskNamedRepository = {
   name: string;
 };
 

--- a/plugins/cad/src/utils/configSync.ts
+++ b/plugins/cad/src/utils/configSync.ts
@@ -99,6 +99,7 @@ export const findRootSyncForPackage = (
   syncs: RootSync[],
   packageRevision: PackageRevision,
   repository: Repository,
+  exactRevision: boolean = true,
 ): RootSync | undefined => {
   const gitRepository = repository.spec.git;
 
@@ -112,7 +113,7 @@ export const findRootSyncForPackage = (
   };
 
   const hashSyncGitSpec = (git: RootSyncGit): string =>
-    `${git.repo}|${git.revision}|${git.dir}|${git.branch}`;
+    `${git.repo}|${exactRevision ? git.revision : ''}|${git.dir}|${git.branch}`;
 
   return syncs.find(
     sync =>


### PR DESCRIPTION
This change allows for new revisions of a package to be created. When a user is on the latest published revision of a package on the Package Revision Page, a 'Create New Revision' button will appear. Clicking on this button will copy the package into a new draft revision and update the page to show the new revision. When a new revision of a package is published, the sync (if one is already created for the package) will automatically update to the new published revision.