### PR TITLE
chore: add script to format code

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
+    "prettier:write": "prettier --write .",
     "create-plugin": "backstage-cli create-plugin --scope internal",
     "remove-plugin": "backstage-cli remove-plugin"
   },


### PR DESCRIPTION
This change adds a new script that formats all code to a consistent style. The can be executed by running `yarn prettier:write`.