### PR TITLE
fix: resources table delete button no longer increases row height

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
@@ -161,6 +161,10 @@ export const PackageRevisionResourcesTable = ({
             key="delete"
             size="small"
             title="Delete"
+            style={{
+              position: 'absolute',
+              transform: 'translateY(-50%)',
+            }}
             onClick={event => {
               event.stopPropagation();
               deleteResource(resourceRow.filename, resourceRow.resourceIndex);


### PR DESCRIPTION
This change updates the styles on the Delete button so the button no longer increase the row height of the Package Resources Table.