### PR TITLE
ci: add release please

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,16 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+handleGHRelease: true
+manifest: true

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ dist
 dist-types
 coverage
 .vscode
+**/CHANGELOG.md

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,4 @@
+{
+  "plugins/cad": "0.0.0",
+  "plugins/cad-backend": "0.0.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,6 @@
+{
+  "packages": {
+    "plugins/cad": {},
+    "plugins/cad-backend": {}
+  }
+}


### PR DESCRIPTION
This change adds Release Please which will propose and create GitHub releases for the Config as Data plugins.