### PR TITLE
feat: show blueprint name on package summary table

### DIFF
--- a/plugins/cad/src/apis/ConfigAsDataApi.ts
+++ b/plugins/cad/src/apis/ConfigAsDataApi.ts
@@ -17,7 +17,10 @@
 import { createApiRef } from '@backstage/core-plugin-api';
 import { Function } from '../types/Function';
 import { PackageRevision } from '../types/PackageRevision';
-import { PackageRevisionResources } from '../types/PackageRevisionResource';
+import {
+  ListPackageRevisionResources,
+  PackageRevisionResources,
+} from '../types/PackageRevisionResource';
 import { ListRepositories, Repository } from '../types/Repository';
 import { ListRootSyncs, RootSync } from '../types/RootSync';
 import { ListSecrets, Secret } from '../types/Secret';
@@ -66,6 +69,8 @@ export type ConfigAsDataApi = {
   getPackageRevisionResources(
     packageName: string,
   ): Promise<PackageRevisionResources>;
+
+  listPackageRevisionResources(): Promise<ListPackageRevisionResources>;
 
   listCatalogFunctions(): Promise<Function[]>;
 

--- a/plugins/cad/src/apis/PorchRestApi.ts
+++ b/plugins/cad/src/apis/PorchRestApi.ts
@@ -19,7 +19,10 @@ import { ConfigAsDataApi } from '.';
 import { Function } from '../types/Function';
 import { KubernetesStatus } from '../types/KubernetesStatus';
 import { PackageRevision } from '../types/PackageRevision';
-import { PackageRevisionResources } from '../types/PackageRevisionResource';
+import {
+  ListPackageRevisionResources,
+  PackageRevisionResources,
+} from '../types/PackageRevisionResource';
 import { ListRepositories, Repository } from '../types/Repository';
 import { ListRootSyncs, RootSync } from '../types/RootSync';
 import { ListSecrets, Secret } from '../types/Secret';
@@ -309,6 +312,14 @@ export class PorchRestAPI implements ConfigAsDataApi {
   ): Promise<PackageRevisionResources> {
     const resourcesResponse = await this.cadFetch(
       `apis/porch.kpt.dev/v1alpha1/namespaces/default/packagerevisionresources/${packageName}`,
+    );
+
+    return resourcesResponse;
+  }
+
+  async listPackageRevisionResources(): Promise<ListPackageRevisionResources> {
+    const resourcesResponse = await this.cadFetch(
+      `apis/porch.kpt.dev/v1alpha1/namespaces/default/packagerevisionresources`,
     );
 
     return resourcesResponse;

--- a/plugins/cad/src/components/Links/PackageLink.tsx
+++ b/plugins/cad/src/components/Links/PackageLink.tsx
@@ -25,11 +25,13 @@ import { useLinkStyles } from './styles';
 type PackageLinkProps = {
   packageRevision: PackageRevision;
   breadcrumb?: boolean;
+  stopPropagation?: boolean;
 };
 
 export const PackageLink = ({
   packageRevision,
   breadcrumb,
+  stopPropagation,
 }: PackageLinkProps) => {
   const packageRef = useRouteRef(packageRouteRef);
 
@@ -42,6 +44,11 @@ export const PackageLink = ({
   return (
     <Link
       className={className}
+      onClick={e => {
+        if (stopPropagation) {
+          e.stopPropagation();
+        }
+      }}
       to={packageRef({ repositoryName, packageName })}
     >
       {getPackageRevisionTitle(packageRevision)}

--- a/plugins/cad/src/components/RepositoryPage/RepositoryPage.tsx
+++ b/plugins/cad/src/components/RepositoryPage/RepositoryPage.tsx
@@ -82,12 +82,25 @@ export const RepositoryPage = () => {
         }
 
         if (isPackageRepository(thisRepository)) {
-          const thisPackageRevisions = await api.listPackageRevisions(
-            repositoryName,
+          const allPackageRevisions = await api.listPackageRevisions();
+          const { items: allPackageRevisionResources } =
+            await api.listPackageRevisionResources();
+
+          const thisPackageRevisions = allPackageRevisions.filter(
+            revision => revision.spec.repository === repositoryName,
           );
+          const upstreamPackageRevisions = repositorySummary.upstreamRepository
+            ? allPackageRevisions.filter(
+                revision =>
+                  revision.spec.repository ===
+                  repositorySummary.upstreamRepository?.metadata.name,
+              )
+            : [];
 
           const thisPackageSummaries = getPackageSummaries(
             thisPackageRevisions,
+            allPackageRevisionResources,
+            upstreamPackageRevisions,
             thisRepository,
           );
           setPackageSummaries(thisPackageSummaries);

--- a/plugins/cad/src/types/PackageRevisionResource.ts
+++ b/plugins/cad/src/types/PackageRevisionResource.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+export type ListPackageRevisionResources = {
+  kind: string;
+  apiVersion: string;
+  items: PackageRevisionResources[];
+};
+
 export type PackageRevisionResources = {
   apiVersion: string;
   kind: string;

--- a/plugins/cad/src/utils/packageRevisionResources.ts
+++ b/plugins/cad/src/utils/packageRevisionResources.ts
@@ -36,6 +36,15 @@ export type PackageResource = {
   resourceIndex: number;
 };
 
+export const getPackageRevisionResources = (
+  packageRevisionResources: PackageRevisionResources[],
+  packageRevisionName: string,
+): PackageRevisionResources => {
+  return packageRevisionResources.find(
+    r => r.metadata.name === packageRevisionName,
+  ) as PackageRevisionResources;
+};
+
 export const getPackageRevisionResourcesResource = (
   fullPackageName: string,
   resourcesMap: PackageRevisionResourcesMap,


### PR DESCRIPTION
This change adds a column to the Package Summary Table that shows the name of the upstream package.