### PR TITLE
fix: do not add an indentation level to array elements

### DIFF
--- a/plugins/cad/src/utils/yaml.ts
+++ b/plugins/cad/src/utils/yaml.ts
@@ -23,7 +23,7 @@ export const loadYaml = (yamlString: string): Yaml => {
 };
 
 export const dumpYaml = (yaml: Yaml): string => {
-  return dump(yaml);
+  return dump(yaml, { noArrayIndent: true });
 };
 
 export const createMultiResourceYaml = (resourcesYaml: string[]): string => {


### PR DESCRIPTION
This change aligns the yaml formatting of the resource editors to the yaml formatting of Porch where an indentation level is not added array elements.