### PR TITLE
feat: show package count on repositories table

### DIFF
--- a/plugins/cad/src/types/RepositorySummary.ts
+++ b/plugins/cad/src/types/RepositorySummary.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+import { PackageSummary } from '../utils/packageSummary';
 import { Repository } from './Repository';
 
 export type RepositorySummary = {
   repository: Repository;
   upstreamRepository?: Repository;
   downstreamRepositories: Repository[];
+  packageSummaries?: PackageSummary[];
 };

--- a/plugins/cad/src/utils/repositorySummary.ts
+++ b/plugins/cad/src/utils/repositorySummary.ts
@@ -15,6 +15,8 @@
  */
 
 import { ConfigAsDataApi } from '../apis';
+import { PackageRevision } from '../types/PackageRevision';
+import { PackageRevisionResources } from '../types/PackageRevisionResource';
 import {
   Repository,
   RepositoryGitDetails,
@@ -22,6 +24,7 @@ import {
   RepositoryUpstream,
 } from '../types/Repository';
 import { RepositorySummary } from '../types/RepositorySummary';
+import { getPackageSummaries } from './packageSummary';
 import { isBlueprintRepository } from './repository';
 
 type RepositoryDetails = RepositoryUpstream;
@@ -81,6 +84,35 @@ export const getRepositorySummary = async (
   }
 
   return repositorySummary;
+};
+
+export const populatePackageSummaries = (
+  repositorySummaries: RepositorySummary[],
+  packageRevisions: PackageRevision[],
+  packageRevisionResources: PackageRevisionResources[],
+) => {
+  for (const repositorySummary of repositorySummaries) {
+    const repositoryPackageRevisions = packageRevisions.filter(
+      revision =>
+        revision.spec.repository === repositorySummary.repository.metadata.name,
+    );
+
+    const upstreamPackageRevisions = packageRevisions.filter(
+      revision =>
+        repositorySummary.upstreamRepository &&
+        revision.spec.repository ===
+          repositorySummary.upstreamRepository.metadata.name,
+    );
+
+    const packageSummaries = getPackageSummaries(
+      repositoryPackageRevisions,
+      packageRevisionResources,
+      upstreamPackageRevisions,
+      repositorySummary.repository,
+    );
+
+    repositorySummary.packageSummaries = packageSummaries;
+  }
 };
 
 export const fitlerRepositorySummary = (


### PR DESCRIPTION
This change adds a column to the Repositories Table that shows the number of published, proposed, and draft packages in each repository.