### PR TITLE
fix: pass current package resources to resource editor dialog

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
@@ -443,7 +443,7 @@ export const PackageRevisionResourcesTable = ({
         onClose={closeDialog}
         yaml={selectedDialogResource.current?.yaml ?? ''}
         onSaveYaml={saveUpdatedYaml}
-        packageResources={allResources}
+        packageResources={packageResources}
       />
 
       <ResourceViewerDialog


### PR DESCRIPTION
This change ensures only the resources that exist in the current package revision are passed to the Resource Editor Dialog.