### PR TITLE
fix: use double quotes when serializing yaml

### DIFF
--- a/plugins/cad/src/utils/yaml.ts
+++ b/plugins/cad/src/utils/yaml.ts
@@ -23,7 +23,7 @@ export const loadYaml = (yamlString: string): Yaml => {
 };
 
 export const dumpYaml = (yaml: Yaml): string => {
-  return dump(yaml, { noArrayIndent: true });
+  return dump(yaml, { noArrayIndent: true, quotingType: '"' });
 };
 
 export const createMultiResourceYaml = (resourcesYaml: string[]): string => {


### PR DESCRIPTION
This change aligns the yaml formatting of the resource editors to kpt and Porch where double quotes are preferred over single quotes.