### PR TITLE
fix: specify tasks list when restoring a package revision

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/PackageRevisionPage.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/PackageRevisionPage.tsx
@@ -484,6 +484,9 @@ export const PackageRevisionPage = ({ mode }: PackageRevisionPageProps) => {
         requestPackageRevision.spec.revision = getNextRevision(
           latestPublishedRevision.spec.revision,
         );
+        requestPackageRevision.spec.tasks = [
+          getEditTask(latestPublishedRevision.metadata.name),
+        ];
         requestPackageRevision.spec.lifecycle = PackageRevisionLifecycle.DRAFT;
 
         const newPackageRevision = await api.createPackageRevision(


### PR DESCRIPTION
This change ensures a task list is always specified when a new restore package revision is being created.