### PR TITLE
feat: default compare revision dropdown

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/PackageRevisionPage.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/PackageRevisionPage.tsx
@@ -226,14 +226,27 @@ export const PackageRevisionPage = ({ mode }: PackageRevisionPageProps) => {
     }
 
     setSelectDiffItems(diffItems);
+
+    const isPublished =
+      thisPackageRevision.spec.lifecycle === PackageRevisionLifecycle.PUBLISHED;
+
+    if (isPublished) {
+      setDiffSelection('none');
+    } else {
+      const updateDiffSelection =
+        !packageRevision ||
+        packageRevision.metadata.name !== thisPackageRevision.metadata.name;
+
+      if (updateDiffSelection) {
+        setDiffSelection((diffItems[1]?.value as string) || 'none');
+      }
+    }
   };
 
   const { loading, error } = useAsync(
     async () => Promise.all([loadRepositorySummary(), loadPackageRevision()]),
     [repositoryName, packageName, mode],
   );
-
-  useEffect(() => setDiffSelection('none'), [repositoryName, packageName]);
 
   useEffect(() => {
     if (!diffSelection || diffSelection === 'none') {


### PR DESCRIPTION
This change updates the Compare Revision dropdown on the Package Revision Page to default to the most relevant revision when a new package revision is created. The dropdown will default to the previous revision when a new revision is created and to upstream when the very first revision of a package is created. The dropdown will default to none when viewing a published revision.