### PR TITLE
feat: add upgrade functionality

### DIFF
--- a/plugins/cad/src/components/RepositoryListPage/components/RepositoriesTable.tsx
+++ b/plugins/cad/src/components/RepositoryListPage/components/RepositoriesTable.tsx
@@ -95,7 +95,13 @@ const getSummary = (packageSummaries?: PackageSummary[]): string => {
   if (draftPackages) {
     summary = `${summary}, ${draftPackages} Draft`;
   }
+  /*
+  const upgradePackages = packageSummaries.filter(summary => summary.isUpgradeAvailable).length;
 
+  if (upgradePackages) {
+    summary = `${summary}, Upgrades Avaialble`
+  }
+*/
   return summary;
 };
 

--- a/plugins/cad/src/components/RepositoryPage/components/PackageSummaryTable.tsx
+++ b/plugins/cad/src/components/RepositoryPage/components/PackageSummaryTable.tsx
@@ -31,6 +31,7 @@ import { isDeploymentRepository } from '../../../utils/repository';
 import { IconButton, PackageIcon } from '../../Controls';
 import { PackageLink } from '../../Links';
 import { SyncStatusVisual } from './SyncStatusVisual';
+import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
 
 type PackageRevisionsTableProps = {
   title: string;
@@ -61,6 +62,7 @@ type PackageSummaryRow = {
   upstreamPackageRevision?: PackageRevision;
   navigate: () => void;
   unpublished?: UnpublishedPackageRevision;
+  isUpgradeAvailable?: boolean;
 };
 
 type NavigateToPackageRevision = (revision: PackageRevision) => void;
@@ -70,20 +72,33 @@ const renderStatusColumn = (
 ): JSX.Element => {
   const unpublishedRevision = thisPackageRevisionRow.unpublished;
 
+  const elements: JSX.Element[] = [];
+
+  if (thisPackageRevisionRow.isUpgradeAvailable) {
+    elements.push(
+      <IconButton title="Upgrade available">
+        <ArrowUpwardIcon />
+      </IconButton>,
+    );
+  }
+
   if (unpublishedRevision) {
-    return (
+    elements.push(
       <IconButton
         title={`${unpublishedRevision.lifecycle} revision`}
-        inTable
         stopPropagation
         onClick={() => unpublishedRevision.navigate()}
       >
         <PackageIcon lifecycle={unpublishedRevision.lifecycle} />
-      </IconButton>
+      </IconButton>,
     );
   }
 
-  return <Fragment />;
+  return (
+    <div style={{ position: 'absolute', transform: 'translateY(-50%)' }}>
+      {...elements}
+    </div>
+  );
 };
 
 const renderBlueprintColumn = (row: PackageSummaryRow): JSX.Element => {
@@ -189,6 +204,7 @@ const mapToPackageSummaryRow = (
     upstreamPackageDisplayName: packageSummary.upstreamPackageName
       ? `${packageSummary.upstreamPackageName} ${packageSummary.upstreamPackageRevision}`
       : undefined,
+    isUpgradeAvailable: packageSummary.isUpgradeAvailable,
     upstreamPackageRevision: packageSummary.upstreamRevision,
     unpublished: mapToUnpublishedRevision(
       packageSummary,

--- a/plugins/cad/src/utils/packageRevision.ts
+++ b/plugins/cad/src/utils/packageRevision.ts
@@ -213,6 +213,37 @@ export const getNextPackageRevisionResource = (
   return resource;
 };
 
+export const getUpgradePackageRevisionResource = (
+  currentRevision: PackageRevision,
+  upgradePackageRevisionName: string,
+): PackageRevision => {
+  const { repository, packageName, revision, tasks } = currentRevision.spec;
+  const nextRevision = getNextRevision(revision);
+
+  const [firstTask, ...remainderTasks] = tasks;
+
+  if (firstTask.type !== 'clone') {
+    throw new Error(
+      `First task of a package revision to be upgraded must be of type 'clone'`,
+    );
+  }
+
+  const newTasks = [
+    getCloneTask(upgradePackageRevisionName),
+    ...remainderTasks,
+  ];
+
+  const resource = getPackageRevisionResource(
+    repository,
+    packageName,
+    nextRevision,
+    PackageRevisionLifecycle.DRAFT,
+    newTasks,
+  );
+
+  return resource;
+};
+
 export const sortByPackageNameAndRevisionComparison = (
   packageRevision1: PackageRevision,
   packageRevision2: PackageRevision,

--- a/plugins/cad/src/utils/packageSummary.ts
+++ b/plugins/cad/src/utils/packageSummary.ts
@@ -21,6 +21,7 @@ import { RepositorySummary } from '../types/RepositorySummary';
 import { RootSync } from '../types/RootSync';
 import { findRootSyncForPackage } from './configSync';
 import {
+  filterPackageRevisions,
   findLatestPublishedRevision,
   findPackageRevision,
   getUpstreamPackageRevisionDetails,
@@ -37,6 +38,8 @@ export type PackageSummary = {
   upstreamRevision?: PackageRevision;
   upstreamPackageName?: string;
   upstreamPackageRevision?: string;
+  upstreamLatestPublishedRevision?: PackageRevision;
+  isUpgradeAvailable?: boolean;
   sync?: RootSync;
 };
 
@@ -91,6 +94,15 @@ export const getPackageSummariesForRepository = (
           upstream.packageName,
           upstream.revision,
         );
+
+        thisPackageSummary.upstreamLatestPublishedRevision =
+          findLatestPublishedRevision(
+            filterPackageRevisions(upstreamRevisions, upstream.packageName),
+          );
+
+        thisPackageSummary.isUpgradeAvailable =
+          thisPackageSummary.upstreamLatestPublishedRevision?.spec.revision !==
+          upstream.revision;
       }
 
       return thisPackageSummary;


### PR DESCRIPTION
This change allows packages to be upgraded to use the latest published blueprint revision. A package can be upgraded by clicking the 'Upgrade to Latest Blueprint' button on the Package Revision Page. This button shows when the latest published revision of a package is shown, and there's a new published revision for the package's blueprint. Additionally, the Packages Table shows a visual indicator when upgrades are available for packages.