### PR TITLE
feat: config sync is optional

### DIFF
--- a/plugins/cad/src/apis/ConfigAsDataApi.ts
+++ b/plugins/cad/src/apis/ConfigAsDataApi.ts
@@ -15,6 +15,8 @@
  */
 
 import { createApiRef } from '@backstage/core-plugin-api';
+import { ListApiGroups } from '../types/ApiGroup';
+import { ListConfigManagements } from '../types/ConfigManagement';
 import { Function } from '../types/Function';
 import { PackageRevision } from '../types/PackageRevision';
 import {
@@ -27,6 +29,10 @@ import { ListSecrets, Secret } from '../types/Secret';
 
 export type ConfigAsDataApi = {
   getFeatures(): Promise<void>;
+
+  listApiGroups(): Promise<ListApiGroups>;
+
+  listConfigManagements(): Promise<ListConfigManagements>;
 
   createSecret(secret: Secret): Promise<Secret>;
 

--- a/plugins/cad/src/apis/PorchRestApi.ts
+++ b/plugins/cad/src/apis/PorchRestApi.ts
@@ -16,6 +16,8 @@
 
 import { DiscoveryApi, FetchApi, OAuthApi } from '@backstage/core-plugin-api';
 import { ConfigAsDataApi } from '.';
+import { ListApiGroups } from '../types/ApiGroup';
+import { ListConfigManagements } from '../types/ConfigManagement';
 import { Function } from '../types/Function';
 import { KubernetesStatus } from '../types/KubernetesStatus';
 import { PackageRevision } from '../types/PackageRevision';
@@ -139,6 +141,20 @@ export class PorchRestAPI implements ConfigAsDataApi {
     const features = await this.cadFetch('v1/features');
 
     this.authentication = features.authentication;
+  }
+
+  async listApiGroups(): Promise<ListApiGroups> {
+    const apiGroups = await this.cadFetch('apis');
+
+    return apiGroups;
+  }
+
+  async listConfigManagements(): Promise<ListConfigManagements> {
+    const configManagements = await this.cadFetch(
+      'apis/configmanagement.gke.io/v1/configmanagements',
+    );
+
+    return configManagements;
   }
 
   async createSecret(secret: Secret): Promise<Secret> {

--- a/plugins/cad/src/components/LandingPage/LandingPage.tsx
+++ b/plugins/cad/src/components/LandingPage/LandingPage.tsx
@@ -29,6 +29,7 @@ import {
   registerRepositoryRouteRef,
   repositoryRouteRef,
 } from '../../routes';
+import { loadFeatures } from '../../utils/featureFlags';
 import { AddPackagePage } from '../AddPackagePage';
 import { PackageRevisionPage } from '../PackageRevisionPage';
 import { PackageRevisionPageMode } from '../PackageRevisionPage/PackageRevisionPage';
@@ -39,7 +40,7 @@ import { RepositoryPage } from '../RepositoryPage';
 export const LandingPage = () => {
   const api = useApi(configAsDataApiRef);
 
-  const { loading, error } = useAsync(() => api.getFeatures(), []);
+  const { loading, error } = useAsync(() => loadFeatures(api), []);
 
   const getContent = (): JSX.Element => {
     if (loading) {

--- a/plugins/cad/src/components/PackageRevisionPage/PackageRevisionPage.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/PackageRevisionPage.tsx
@@ -45,6 +45,7 @@ import {
   SyncStatus,
   SyncStatusState,
 } from '../../utils/configSync';
+import { isConfigSyncEnabled } from '../../utils/featureFlags';
 import {
   filterPackageRevisions,
   findLatestPublishedRevision,
@@ -144,6 +145,8 @@ export const PackageRevisionPage = ({ mode }: PackageRevisionPageProps) => {
   const [isUpgradeAvailable, setIsUpgradeAvailable] = useState<boolean>(false);
 
   const latestPublishedUpstream = useRef<PackageRevision>();
+
+  const configSyncEnabled = isConfigSyncEnabled();
 
   const loadRepositorySummary = async (): Promise<void> => {
     const thisRepositorySummary = await getRepositorySummary(
@@ -286,7 +289,11 @@ export const PackageRevisionPage = ({ mode }: PackageRevisionPageProps) => {
 
   useAsync(async () => {
     if (!loading && packageRevision && repositorySummary) {
-      if (isLatestPublishedPackageRevision && isDeploymentPackage) {
+      if (
+        isLatestPublishedPackageRevision &&
+        isDeploymentPackage &&
+        configSyncEnabled
+      ) {
         const { items: allRootSyncs } = await api.listRootSyncs();
 
         const thisRootSync = findRootSyncForPackage(
@@ -400,7 +407,7 @@ export const PackageRevisionPage = ({ mode }: PackageRevisionPageProps) => {
 
       await api.approvePackageRevision(targetRevision);
 
-      if (isDeploymentPackage) {
+      if (isDeploymentPackage && configSyncEnabled) {
         await updateRootSyncToLatestPackage(targetRevision);
       }
 

--- a/plugins/cad/src/types/ApiGroup.ts
+++ b/plugins/cad/src/types/ApiGroup.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type ListApiGroups = {
+  kind: string;
+  apiVersion: string;
+  groups: ApiGroup[];
+};
+
+export type ApiGroup = {
+  name: string;
+  preferredVersion: ApiGroupVersion;
+  versions: ApiGroupVersion[];
+};
+
+export type ApiGroupVersion = {
+  groupVersion: string;
+  version: string;
+};

--- a/plugins/cad/src/types/ConfigManagement.ts
+++ b/plugins/cad/src/types/ConfigManagement.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubernetesKeyValueObject } from './KubernetesResource';
+
+export type ListConfigManagements = {
+  kind: string;
+  apiVersion: string;
+  items: ConfigManagement[];
+};
+
+export type ConfigManagement = {
+  apiVersion: string;
+  kind: string;
+  metadata: ConfigManagementMetadata;
+  spec: ConfigManagementSpec;
+  status?: ConfigManagementStatus;
+};
+
+export type ConfigManagementMetadata = {
+  name: string;
+  labels?: KubernetesKeyValueObject;
+  annotations?: KubernetesKeyValueObject;
+};
+
+export type ConfigManagementSpec = {
+  enableMultiRepo: boolean;
+};
+
+export type ConfigManagementStatus = {
+  configManagementVersion?: string;
+  healthy: boolean;
+};

--- a/plugins/cad/src/utils/featureFlags.ts
+++ b/plugins/cad/src/utils/featureFlags.ts
@@ -14,6 +14,28 @@
  * limitations under the License.
  */
 
+import { ConfigAsDataApi } from '../apis';
+
+let isConfigSyncInstalled = false;
+
+export const isConfigSyncEnabled = (): boolean => isConfigSyncInstalled;
+
 export const allowFunctionRepositoryRegistration = (): boolean => false;
 
 export const showRegisteredFunctionRepositories = (): boolean => false;
+
+export const loadFeatures = async (api: ConfigAsDataApi): Promise<void> => {
+  await api.getFeatures();
+
+  const { groups } = await api.listApiGroups();
+
+  const configManagementGroupExists = !!groups.find(
+    apiGroup => apiGroup.name === 'configmanagement.gke.io',
+  );
+
+  if (configManagementGroupExists) {
+    const { items: configManagements } = await api.listConfigManagements();
+
+    isConfigSyncInstalled = configManagements.length > 0;
+  }
+};


### PR DESCRIPTION
This change allows the Config as Data UI to use clusters that Config Sync is not installed on.