### PR TITLE
fix: allow upstream package comparison

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/PackageRevisionPage.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/PackageRevisionPage.tsx
@@ -211,34 +211,34 @@ export const PackageRevisionPage = ({ mode }: PackageRevisionPageProps) => {
 
     let upgradeAvailable = false;
 
-    if (isLatestPublishedRevision(thisPackageRevision)) {
-      const upstream = getUpstreamPackageRevisionDetails(thisPackageRevision);
+    const upstream = getUpstreamPackageRevisionDetails(thisPackageRevision);
 
-      if (upstream) {
-        const upstreamPackage = findPackageRevision(
-          thisPackageRevisions,
-          upstream.packageName,
-          upstream.revision,
-        );
+    if (upstream) {
+      const upstreamPackage = findPackageRevision(
+        thisPackageRevisions,
+        upstream.packageName,
+        upstream.revision,
+      );
 
-        if (upstreamPackage) {
-          diffItems.push({
-            label: `Upstream (${getPackageRevisionTitle(upstreamPackage)})`,
-            value: upstreamPackage.metadata.name,
-          });
-        }
+      if (upstreamPackage) {
+        diffItems.push({
+          label: `Upstream (${getPackageRevisionTitle(upstreamPackage)})`,
+          value: upstreamPackage.metadata.name,
+        });
 
-        const allUpstreamRevisions = filterPackageRevisions(
-          thisPackageRevisions,
-          upstream.packageName,
-        );
-        latestPublishedUpstream.current =
-          findLatestPublishedRevision(allUpstreamRevisions);
+        if (isLatestPublishedRevision(thisPackageRevision)) {
+          const allUpstreamRevisions = filterPackageRevisions(
+            thisPackageRevisions,
+            upstream.packageName,
+          );
+          latestPublishedUpstream.current =
+            findLatestPublishedRevision(allUpstreamRevisions);
 
-        if (
-          upstream.revision !== latestPublishedUpstream.current?.spec.revision
-        ) {
-          upgradeAvailable = true;
+          if (
+            upstream.revision !== latestPublishedUpstream.current?.spec.revision
+          ) {
+            upgradeAvailable = true;
+          }
         }
       }
     }


### PR DESCRIPTION
This change ensures the Compare Revision dropdown on the Package Revision Page always lists the upstream package anytime the upstream package is known.