### PR TITLE
fix: allow latest published blueprint to be deployed

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionOptions.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionOptions.tsx
@@ -199,24 +199,38 @@ const PublishedPackageRevisionOptions = ({
     );
   }
 
-  if (latestRevision !== latestPublishedRevision) {
-    return (
-      <Button
-        to={packageRef({
-          repositoryName,
-          packageName: latestRevision.metadata.name,
-        })}
-        color="primary"
-        variant="outlined"
-      >
-        View {latestRevision.spec.lifecycle} Revision
-      </Button>
-    );
-  }
-
   const showDeploy =
     repositorySummary.downstreamRepositories.length > 0 &&
     canCloneOrDeploy(packageRevision);
+
+  if (latestRevision !== latestPublishedRevision) {
+    return (
+      <Fragment>
+        <Button
+          to={packageRef({
+            repositoryName,
+            packageName: latestRevision.metadata.name,
+          })}
+          color="primary"
+          variant="outlined"
+        >
+          View {latestRevision.spec.lifecycle} Revision
+        </Button>
+
+        {showDeploy && (
+          <Button
+            to={deployPackageRef({ repositoryName, packageName })}
+            color="primary"
+            variant="contained"
+            disabled={disabled}
+          >
+            Deploy
+          </Button>
+        )}
+      </Fragment>
+    );
+  }
+
   const showCreateSync =
     isDeploymentRepository(repositorySummary.repository) && rootSync === null;
 


### PR DESCRIPTION
This change ensures the 'Deploy' button shows on the Package Revision Page for the latest published revision of a blueprint. 