### PR TITLE
feat: allow blueprints to be deployed to any deployment repository

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionOptions.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionOptions.tsx
@@ -34,7 +34,10 @@ import {
   findLatestPublishedRevision,
   isLatestPublishedRevision,
 } from '../../../utils/packageRevision';
-import { isDeploymentRepository } from '../../../utils/repository';
+import {
+  isBlueprintRepository,
+  isDeploymentRepository,
+} from '../../../utils/repository';
 import { PackageRevisionPageMode } from '../PackageRevisionPage';
 
 export enum RevisionOption {
@@ -200,7 +203,7 @@ const PublishedPackageRevisionOptions = ({
   }
 
   const showDeploy =
-    repositorySummary.downstreamRepositories.length > 0 &&
+    isBlueprintRepository(repositorySummary.repository) &&
     canCloneOrDeploy(packageRevision);
 
   if (latestRevision !== latestPublishedRevision) {

--- a/plugins/cad/src/utils/packageSummary.ts
+++ b/plugins/cad/src/utils/packageSummary.ts
@@ -45,7 +45,7 @@ export type PackageSummary = {
 
 export const getPackageSummariesForRepository = (
   packageRevisions: PackageRevision[],
-  upstreamRevisions: PackageRevision[],
+  allPackageRevisions: PackageRevision[],
   repository: Repository,
 ): PackageSummary[] => {
   const latestPackageRevisions = packageRevisions.filter(
@@ -90,14 +90,14 @@ export const getPackageSummariesForRepository = (
         thisPackageSummary.upstreamPackageRevision = upstream.revision;
 
         thisPackageSummary.upstreamRevision = findPackageRevision(
-          upstreamRevisions,
+          allPackageRevisions,
           upstream.packageName,
           upstream.revision,
         );
 
         thisPackageSummary.upstreamLatestPublishedRevision =
           findLatestPublishedRevision(
-            filterPackageRevisions(upstreamRevisions, upstream.packageName),
+            filterPackageRevisions(allPackageRevisions, upstream.packageName),
           );
 
         thisPackageSummary.isUpgradeAvailable =
@@ -124,16 +124,9 @@ export const getPackageSummaries = (
         revision.spec.repository === repositorySummary.repository.metadata.name,
     );
 
-    const upstreamPackageRevisions = packageRevisions.filter(
-      revision =>
-        repositorySummary.upstreamRepository &&
-        revision.spec.repository ===
-          repositorySummary.upstreamRepository.metadata.name,
-    );
-
     const repositoryPackageSummaries = getPackageSummariesForRepository(
       repositoryPackageRevisions,
-      upstreamPackageRevisions,
+      packageRevisions,
       repositorySummary.repository,
     );
 


### PR DESCRIPTION
This change allows blueprints to deployed to any deployment repository regardless if the deployment repository's upstream is set the blueprint's repository.