### PR TITLE
feat: update resources table to show component a resource exists in

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
@@ -212,6 +212,7 @@ export const PackageRevisionResourcesTable = ({
   };
 
   const columns: TableColumn<ResourceRow>[] = [
+    { title: 'Component', field: 'component' },
     { title: 'Kind', field: 'kind' },
     { title: 'Name', field: 'name' },
     { title: 'Namespace', field: 'namespace' },
@@ -220,7 +221,7 @@ export const PackageRevisionResourcesTable = ({
   ];
 
   if (baseResourcesMap) {
-    columns[3] = { title: 'Diff', render: renderDiffColumn };
+    columns[4] = { title: 'Diff', render: renderDiffColumn };
   }
 
   const packageResources = getPackageResourcesFromResourcesMap(
@@ -240,8 +241,20 @@ export const PackageRevisionResourcesTable = ({
       return 0;
     };
 
+    const resourceComponent = (resource: ResourceRow): string => {
+      if (resource.component === 'base') return '';
+
+      return resource.component;
+    };
+
     const resourceQualifiedName = (resource: ResourceRow): string =>
       (resource.namespace || ' ') + resource.kind + resource.name;
+
+    if (resourceComponent(resource1) !== resourceComponent(resource2)) {
+      return resourceComponent(resource1) > resourceComponent(resource2)
+        ? 1
+        : -1;
+    }
 
     if (resourceScore(resource1) === resourceScore(resource2)) {
       return resourceQualifiedName(resource1) > resourceQualifiedName(resource2)

--- a/plugins/cad/src/utils/packageRevisionResources.ts
+++ b/plugins/cad/src/utils/packageRevisionResources.ts
@@ -29,6 +29,7 @@ import {
 
 export type PackageResource = {
   id: string;
+  component: string;
   kind: string;
   name: string;
   namespace?: string;
@@ -108,7 +109,10 @@ export const getPackageResourcesFromResourcesMap = (
   resourcesMap: PackageRevisionResourcesMap,
 ): PackageResource[] => {
   const yamlFileEntries = Object.entries(resourcesMap).filter(
-    file => file[0].endsWith('.yaml') || file[0] === 'Kptfile',
+    file =>
+      file[0].endsWith('.yaml') ||
+      file[0] === 'Kptfile' ||
+      file[0].endsWith('/Kptfile'),
   );
 
   const resources = yamlFileEntries.map(([filename, multiResourceYaml]) => {
@@ -123,6 +127,7 @@ export const getPackageResourcesFromResourcesMap = (
 
       return {
         id: uniqueId,
+        component: filename.substring(0, filename.lastIndexOf('/')) || 'base',
         filename: filename,
         kind: k8sResource.kind,
         name: k8sResource.metadata.name,


### PR DESCRIPTION
This change adds a column to the Resources Table in the Package Revision Page to show the component that a resource belongs to.