### PR TITLE
feat: preserve white space in resource viewers

### DIFF
--- a/plugins/cad/src/components/ResourceViewerDialog/ResourceViewerDialog.tsx
+++ b/plugins/cad/src/components/ResourceViewerDialog/ResourceViewerDialog.tsx
@@ -38,11 +38,12 @@ type ResourceViewerProps = {
 
 const useStyles = makeStyles({
   container: {
-    width: '600px',
+    width: '620px',
     minHeight: '300px',
     maxHeight: '50vh',
     marginBottom: '10px',
     overflowY: 'scroll',
+    whiteSpace: 'pre',
   },
 });
 


### PR DESCRIPTION
This change ensures that white space is always preserved in the resource viewers. Preserving of white space allows resources with multiline values to be correctly displayed.