### PR TITLE
feat: ignore whitespace in resource yaml diff

### DIFF
--- a/plugins/cad/src/utils/packageRevisionResources.ts
+++ b/plugins/cad/src/utils/packageRevisionResources.ts
@@ -235,7 +235,9 @@ export const diffPackageResource = (
       };
     }
 
-    const thisDiff = diffLines(originalResource.yaml, currentResource.yaml);
+    const thisDiff = diffLines(originalResource.yaml, currentResource.yaml, {
+      ignoreWhitespace: true,
+    });
     const linesAdded = sum(thisDiff.filter(d => !!d.added).map(d => d.count));
     const linesRemoved = sum(
       thisDiff.filter(d => !!d.removed).map(d => d.count),


### PR DESCRIPTION
This change updates the resource diff logic to ignore whitespace when comparing yaml.