### PR TITLE
feat: create separate resources table for each component

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageResourcesList.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageResourcesList.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { makeStyles } from '@material-ui/core';
+import { uniq } from 'lodash';
 import React, { Fragment } from 'react';
 import { PackageRevisionResourcesMap } from '../../../types/PackageRevisionResource';
 import {
@@ -55,8 +57,6 @@ const sortResources = (allResources: ResourceRow[]): void => {
     };
 
     const resourceComponent = (resource: ResourceRow): string => {
-      if (resource.component === 'base') return '';
-
       return resource.component;
     };
 
@@ -131,12 +131,20 @@ const addDiffDetails = (
   }
 };
 
+const useStyles = makeStyles({
+  alert: {
+    marginBottom: '24px',
+  },
+});
+
 export const PackageResourcesList = ({
   resourcesMap,
   baseResourcesMap,
   onUpdatedResourcesMap,
   mode,
 }: PackageResourcesListProps) => {
+  const classes = useStyles();
+
   const packageResources = getPackageResourcesFromResourcesMap(
     resourcesMap,
   ) as ResourceRow[];
@@ -185,6 +193,10 @@ export const PackageResourcesList = ({
     onUpdatedResourcesMap(updatedResourcesMap);
   };
 
+  const uniqueComponents = uniq(
+    allResources.map(resource => resource.component),
+  );
+
   const resourcesTableMode =
     mode === PackageRevisionPageMode.EDIT
       ? ResourcesTableMode.EDIT
@@ -192,12 +204,18 @@ export const PackageResourcesList = ({
 
   return (
     <Fragment>
-      <PackageRevisionResourcesTable
-        allResources={allResources}
-        mode={resourcesTableMode}
-        showDiff={!!baseResourcesMap}
-        onUpdatedResource={onUpdatedResource}
-      />
+      {uniqueComponents.map(component => (
+        <div key={component} className={classes.alert}>
+          <PackageRevisionResourcesTable
+            title={`${component || 'root'} resources`}
+            allResources={allResources}
+            component={component}
+            mode={resourcesTableMode}
+            showDiff={!!baseResourcesMap}
+            onUpdatedResource={onUpdatedResource}
+          />
+        </div>
+      ))}
     </Fragment>
   );
 };

--- a/plugins/cad/src/utils/packageRevisionResources.ts
+++ b/plugins/cad/src/utils/packageRevisionResources.ts
@@ -127,7 +127,7 @@ export const getPackageResourcesFromResourcesMap = (
 
       return {
         id: uniqueId,
-        component: filename.substring(0, filename.lastIndexOf('/')) || 'base',
+        component: filename.substring(0, filename.lastIndexOf('/')),
         filename: filename,
         kind: k8sResource.kind,
         name: k8sResource.metadata.name,


### PR DESCRIPTION
This change creates a separate Resources Table for each component in the package's resources on the Package Revisions Page, removing the component column previously added to the Resources Table.