### PR TITLE
feat: show downstream packages

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/DownstreamTabContent.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/DownstreamTabContent.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { makeStyles } from '@material-ui/core';
+import { groupBy, uniq } from 'lodash';
+import React, { Fragment } from 'react';
+import { PackageSummary } from '../../../utils/packageSummary';
+import {
+  ContentSummary,
+  PackageContentSummaryOrder,
+} from '../../../utils/repository';
+import { PackagesTable } from '../../PackagesTable';
+
+type ResourcesTabContentProps = {
+  packageDescriptor: string;
+  downstreamPackages: PackageSummary[];
+};
+
+const useStyles = makeStyles({
+  packagesTable: {
+    marginBottom: '24px',
+  },
+});
+
+export const DownstreamTabContent = ({
+  packageDescriptor,
+  downstreamPackages,
+}: ResourcesTabContentProps) => {
+  const classes = useStyles();
+
+  const getDesciptorPriority = (descriptor: string): number =>
+    PackageContentSummaryOrder.indexOf(descriptor as ContentSummary);
+  const compareDescriptors = (
+    descriptor1: string,
+    descriptor2: string,
+  ): number =>
+    getDesciptorPriority(descriptor1) > getDesciptorPriority(descriptor2)
+      ? 1
+      : -1;
+
+  const requiredDescriptorToShow =
+    PackageContentSummaryOrder[getDesciptorPriority(packageDescriptor) - 1];
+  const packagesByDescriptor = groupBy(
+    downstreamPackages,
+    packageSummary => packageSummary.packageDescriptor,
+  );
+
+  const packageDescriptorsToDisplay = uniq([
+    requiredDescriptorToShow,
+    ...Object.keys(packagesByDescriptor),
+  ]).sort(compareDescriptors);
+
+  return (
+    <Fragment>
+      {packageDescriptorsToDisplay.map(descriptor => (
+        <div key={descriptor} className={classes.packagesTable}>
+          <PackagesTable
+            title={`${descriptor}s`}
+            packages={packagesByDescriptor[descriptor] ?? []}
+            showRepositoryColumn
+          />
+        </div>
+      ))}
+    </Fragment>
+  );
+};

--- a/plugins/cad/src/utils/packageSummary.ts
+++ b/plugins/cad/src/utils/packageSummary.ts
@@ -29,7 +29,7 @@ import {
   isNotAPublishedRevision,
   sortByPackageNameAndRevisionComparison,
 } from './packageRevision';
-import { findRepository } from './repository';
+import { findRepository, getPackageDescriptor } from './repository';
 
 export type PackageSummary = {
   repository: Repository;
@@ -38,9 +38,11 @@ export type PackageSummary = {
   unpublishedRevision?: PackageRevision;
   upstreamRevision?: PackageRevision;
   upstreamPackageName?: string;
+  upstreamRepositoryName?: string;
   upstreamPackageRevision?: string;
   upstreamLatestPublishedRevision?: PackageRevision;
   isUpgradeAvailable?: boolean;
+  packageDescriptor: string;
   sync?: RootSync;
 };
 
@@ -77,11 +79,14 @@ export const getPackageSummariesForRepository = (
         ? latestRevision
         : undefined;
 
+      const packageDescriptor = getPackageDescriptor(repository);
+
       const thisPackageSummary: PackageSummary = {
         repository,
         latestRevision,
         latestPublishedRevision,
         unpublishedRevision,
+        packageDescriptor,
       };
 
       const useRevision = latestPublishedRevision ?? latestRevision;
@@ -97,6 +102,7 @@ export const getPackageSummariesForRepository = (
 
         if (upstreamRepository) {
           const upstreamRepositoryName = upstreamRepository.metadata.name;
+          thisPackageSummary.upstreamRepositoryName = upstreamRepositoryName;
 
           thisPackageSummary.upstreamRevision = findPackageRevision(
             allPackageRevisions,

--- a/plugins/cad/src/utils/repository.ts
+++ b/plugins/cad/src/utils/repository.ts
@@ -35,6 +35,12 @@ export enum ContentSummary {
   FUNCTION = 'Function',
 }
 
+export const PackageContentSummaryOrder = [
+  ContentSummary.DEPLOYMENT,
+  ContentSummary.BLUEPRINT,
+  ContentSummary.CATALOG_BLUEPRINT,
+];
+
 export const isFunctionRepository = (repository: Repository): boolean => {
   return repository.spec.content === RepositoryContent.FUNCTION;
 };


### PR DESCRIPTION
This change adds the Downstream tab to the Package Revision page to show the downstream packages for the current package. The tab is hidden for deployment packages since deployments will not have any downstream packages.