### PR TITLE
fix: allow resource editors access to current resources list

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
@@ -334,7 +334,7 @@ export const PackageRevisionResourcesTable = ({
   };
 
   const packageResources = resources
-    .map(resource => resource.originalResource)
+    .map(resource => resource.currentResource)
     .filter(resource => !!resource) as PackageResource[];
 
   return (


### PR DESCRIPTION
This change allows the resource editors access the resource list of the package.