### PR TITLE
feat: group resource metadata in resource editors

### DIFF
--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/ApplyReplacementsEditor/ApplyReplacementsEditor.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/ApplyReplacementsEditor/ApplyReplacementsEditor.tsx
@@ -33,8 +33,7 @@ import { sortByLabel } from '../../../../../utils/selectItem';
 import { dumpYaml, loadYaml } from '../../../../../utils/yaml';
 import { Select } from '../../../../Controls/Select';
 import { EditorAccordion } from '../Controls/EditorAccordion';
-import { KeyValueEditorAccordion } from '../Controls/KeyValueEditorAccordion';
-import { SingleTextFieldAccordion } from '../Controls/SingleTextFieldAccordion';
+import { ResourceMetadataAccordion } from '../Controls/ResourceMetadataAccordion';
 import { useEditorStyles } from '../styles';
 
 type OnUpdatedYamlFn = (yaml: string) => void;
@@ -47,8 +46,8 @@ type ApplyReplacementsEditorProps = {
 
 type State = {
   name: string;
-  annotations: KubernetesKeyValueObject;
-  labels: KubernetesKeyValueObject;
+  annotations?: KubernetesKeyValueObject;
+  labels?: KubernetesKeyValueObject;
 };
 
 type ReplacementState = {
@@ -211,8 +210,8 @@ export const ApplyReplacementsEditor = ({
 
   const createResourceState = (): State => ({
     name: resourceYaml.metadata.name,
-    annotations: resourceYaml.metadata.annotations ?? {},
-    labels: resourceYaml.metadata.labels ?? {},
+    annotations: resourceYaml.metadata.annotations,
+    labels: resourceYaml.metadata.labels,
   });
 
   const createReplacementState = (
@@ -302,13 +301,6 @@ export const ApplyReplacementsEditor = ({
       },
     ];
 
-    if (state.annotations && Object.keys(state.annotations).length === 0) {
-      delete resourceYaml.metadata.annotations;
-    }
-    if (state.labels && Object.keys(state.labels).length === 0) {
-      delete resourceYaml.metadata.labels;
-    }
-
     onUpdatedYaml(dumpYaml(resourceYaml));
   }, [state, sourceState, targetState, onUpdatedYaml, resourceYaml]);
 
@@ -319,31 +311,16 @@ export const ApplyReplacementsEditor = ({
 
   return (
     <div className={classes.root}>
-      <SingleTextFieldAccordion
-        title="Name"
-        expanded={expanded === 'name'}
-        onChange={handleChange('name')}
-        value={state.name}
-        onValueUpdated={value => setState(s => ({ ...s, name: value }))}
+      <ResourceMetadataAccordion
+        clusterScopedResource
+        expanded={expanded === 'metadata'}
+        onChange={handleChange('metadata')}
+        value={state}
+        onUpdate={v => {
+          setState(s => ({ ...s, ...v }));
+        }}
       />
-      <KeyValueEditorAccordion
-        title="Annotations"
-        expanded={expanded === 'annotations'}
-        onChange={handleChange('annotations')}
-        keyValueObject={state.annotations}
-        onUpdatedKeyValueObject={data =>
-          setState(s => ({ ...s, annotations: data }))
-        }
-      />
-      <KeyValueEditorAccordion
-        title="Labels"
-        expanded={expanded === 'labels'}
-        onChange={handleChange('labels')}
-        keyValueObject={state.labels}
-        onUpdatedKeyValueObject={data =>
-          setState(s => ({ ...s, labels: data }))
-        }
-      />
+
       <EditorAccordion
         title="Source"
         description={`${sourceState.resourceKind} ${sourceState.resourceName}`}

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/ConfigMapEditor/ConfigMapEditor.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/ConfigMapEditor/ConfigMapEditor.tsx
@@ -19,7 +19,7 @@ import { ConfigMap } from '../../../../../types/ConfigMap';
 import { KubernetesKeyValueObject } from '../../../../../types/KubernetesResource';
 import { dumpYaml, loadYaml } from '../../../../../utils/yaml';
 import { KeyValueEditorAccordion } from '../Controls/KeyValueEditorAccordion';
-import { SingleTextFieldAccordion } from '../Controls/SingleTextFieldAccordion';
+import { ResourceMetadataAccordion } from '../Controls/ResourceMetadataAccordion';
 import { useEditorStyles } from '../styles';
 
 type OnUpdatedYamlFn = (yaml: string) => void;
@@ -31,10 +31,10 @@ type ResourceEditorProps = {
 
 type State = {
   name: string;
-  namespace: string;
+  namespace?: string;
   data: KubernetesKeyValueObject;
-  annotations: KubernetesKeyValueObject;
-  labels: KubernetesKeyValueObject;
+  annotations?: KubernetesKeyValueObject;
+  labels?: KubernetesKeyValueObject;
 };
 
 export const ConfigMapEditor = ({
@@ -45,9 +45,9 @@ export const ConfigMapEditor = ({
 
   const createResourceState = (): State => ({
     name: resourceYaml.metadata.name,
-    annotations: resourceYaml.metadata.annotations ?? {},
-    labels: resourceYaml.metadata.labels ?? {},
-    namespace: resourceYaml.metadata.namespace ?? '',
+    annotations: resourceYaml.metadata.annotations,
+    labels: resourceYaml.metadata.labels,
+    namespace: resourceYaml.metadata.namespace,
     data: resourceYaml.data,
   });
 
@@ -63,55 +63,25 @@ export const ConfigMapEditor = ({
 
   useEffect(() => {
     resourceYaml.metadata.name = state.name;
-    resourceYaml.metadata.namespace = state.namespace || undefined;
+    resourceYaml.metadata.namespace = state.namespace;
     resourceYaml.metadata.labels = state.labels;
     resourceYaml.metadata.annotations = state.annotations;
     resourceYaml.data = state.data;
-
-    if (state.annotations && Object.keys(state.annotations).length === 0) {
-      delete resourceYaml.metadata.annotations;
-    }
-    if (state.labels && Object.keys(state.labels).length === 0) {
-      delete resourceYaml.metadata.labels;
-    }
 
     onUpdatedYaml(dumpYaml(resourceYaml));
   }, [state, resourceYaml, onUpdatedYaml]);
 
   return (
     <div className={classes.root}>
-      <SingleTextFieldAccordion
-        title="Name"
-        expanded={expanded === 'name'}
-        onChange={handleChange('name')}
-        value={state.name}
-        onValueUpdated={value => setState(s => ({ ...s, name: value }))}
+      <ResourceMetadataAccordion
+        expanded={expanded === 'metadata'}
+        onChange={handleChange('metadata')}
+        value={state}
+        onUpdate={v => {
+          setState(s => ({ ...s, ...v }));
+        }}
       />
-      <SingleTextFieldAccordion
-        title="Namespace"
-        expanded={expanded === 'namespace'}
-        onChange={handleChange('namespace')}
-        value={state.namespace}
-        onValueUpdated={value => setState(s => ({ ...s, namespace: value }))}
-      />
-      <KeyValueEditorAccordion
-        title="Annotations"
-        expanded={expanded === 'annotations'}
-        onChange={handleChange('annotations')}
-        keyValueObject={state.annotations}
-        onUpdatedKeyValueObject={data =>
-          setState(s => ({ ...s, annotations: data }))
-        }
-      />
-      <KeyValueEditorAccordion
-        title="Labels"
-        expanded={expanded === 'labels'}
-        onChange={handleChange('labels')}
-        keyValueObject={state.labels}
-        onUpdatedKeyValueObject={data =>
-          setState(s => ({ ...s, labels: data }))
-        }
-      />
+
       <KeyValueEditorAccordion
         title="Data"
         expanded={expanded === 'data'}

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/Controls/ResourceMetadataAccordion.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/Controls/ResourceMetadataAccordion.tsx
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TextField } from '@material-ui/core';
+import React, { ChangeEvent, Fragment, useRef, useState } from 'react';
+import { KubernetesKeyValueObject } from '../../../../../types/KubernetesResource';
+import { EditorAccordion, OnAccordionChange } from './EditorAccordion';
+import { KeyValueEditorAccordion } from './KeyValueEditorAccordion';
+
+type OnUpdate = (value: ResourceMetadataView) => void;
+
+type ResourceMetadataView = {
+  name: string;
+  namespace?: string;
+  labels?: KubernetesKeyValueObject;
+  annotations?: KubernetesKeyValueObject;
+};
+
+type ResourceMetadataAccordionProps = {
+  expanded: boolean;
+  onChange: OnAccordionChange;
+  value: ResourceMetadataView;
+  onUpdate: OnUpdate;
+  clusterScopedResource?: boolean;
+};
+
+export const ResourceMetadataAccordion = ({
+  expanded: thisExpanded,
+  onChange,
+  value,
+  onUpdate,
+  clusterScopedResource,
+}: ResourceMetadataAccordionProps) => {
+  const refViewModel = useRef<ResourceMetadataView>(value);
+  const viewModel = refViewModel.current;
+
+  const [expanded, setExpanded] = useState<string>();
+  const handlePanelChange =
+    (panel: string) => (_: ChangeEvent<{}>, newExpanded: boolean) => {
+      setExpanded(newExpanded ? panel : undefined);
+    };
+
+  const description = `${viewModel.namespace ? `${viewModel.namespace}/` : ''}${
+    viewModel.name
+  }`;
+
+  const valueUpdated = (): void => {
+    onUpdate(viewModel);
+  };
+
+  return (
+    <EditorAccordion
+      title="Resource Metadata"
+      description={description}
+      expanded={thisExpanded}
+      onChange={onChange}
+    >
+      <Fragment>
+        <TextField
+          label="Name"
+          variant="outlined"
+          value={viewModel.name}
+          onChange={e => {
+            viewModel.name = e.target.value;
+            valueUpdated();
+          }}
+          fullWidth
+        />
+
+        {!clusterScopedResource && (
+          <TextField
+            label="Namespace"
+            variant="outlined"
+            value={viewModel.namespace ?? ''}
+            onChange={e => {
+              viewModel.namespace = e.target.value || undefined;
+              valueUpdated();
+            }}
+            fullWidth
+          />
+        )}
+
+        <div>
+          <KeyValueEditorAccordion
+            title="Labels"
+            expanded={expanded === 'labels'}
+            onChange={handlePanelChange('labels')}
+            keyValueObject={viewModel.labels || {}}
+            onUpdatedKeyValueObject={labels => {
+              viewModel.labels =
+                Object.keys(labels).length > 0 ? labels : undefined;
+              valueUpdated();
+            }}
+          />
+
+          <KeyValueEditorAccordion
+            title="Annotations"
+            expanded={expanded === 'annotations'}
+            onChange={handlePanelChange('annotations')}
+            keyValueObject={viewModel.annotations || {}}
+            onUpdatedKeyValueObject={annotations => {
+              viewModel.annotations =
+                Object.keys(annotations).length > 0 ? annotations : undefined;
+              valueUpdated();
+            }}
+          />
+        </div>
+      </Fragment>
+    </EditorAccordion>
+  );
+};

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/NamespaceEditor/NamespaceEditor.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/NamespaceEditor/NamespaceEditor.tsx
@@ -18,8 +18,7 @@ import React, { ChangeEvent, useEffect, useState } from 'react';
 import { KubernetesKeyValueObject } from '../../../../../types/KubernetesResource';
 import { Namespace } from '../../../../../types/Namespace';
 import { dumpYaml, loadYaml } from '../../../../../utils/yaml';
-import { KeyValueEditorAccordion } from '../Controls/KeyValueEditorAccordion';
-import { SingleTextFieldAccordion } from '../Controls/SingleTextFieldAccordion';
+import { ResourceMetadataAccordion } from '../Controls/ResourceMetadataAccordion';
 import { useEditorStyles } from '../styles';
 
 type OnUpdatedYamlFn = (yaml: string) => void;
@@ -31,8 +30,8 @@ type ResourceEditorProps = {
 
 type State = {
   name: string;
-  annotations: KubernetesKeyValueObject;
-  labels: KubernetesKeyValueObject;
+  annotations?: KubernetesKeyValueObject;
+  labels?: KubernetesKeyValueObject;
 };
 
 export const NamespaceEditor = ({
@@ -43,8 +42,8 @@ export const NamespaceEditor = ({
 
   const createResourceState = (): State => ({
     name: resourceYaml.metadata.name,
-    annotations: resourceYaml.metadata.annotations ?? {},
-    labels: resourceYaml.metadata.labels ?? {},
+    annotations: resourceYaml.metadata.annotations,
+    labels: resourceYaml.metadata.labels,
   });
 
   const [state, setState] = useState<State>(createResourceState);
@@ -62,42 +61,19 @@ export const NamespaceEditor = ({
     resourceYaml.metadata.labels = state.labels;
     resourceYaml.metadata.annotations = state.annotations;
 
-    if (state.annotations && Object.keys(state.annotations).length === 0) {
-      delete resourceYaml.metadata.annotations;
-    }
-    if (state.labels && Object.keys(state.labels).length === 0) {
-      delete resourceYaml.metadata.labels;
-    }
-
     onUpdatedYaml(dumpYaml(resourceYaml));
   }, [state, onUpdatedYaml, resourceYaml]);
 
   return (
     <div className={classes.root}>
-      <SingleTextFieldAccordion
-        title="Name"
-        expanded={expanded === 'name'}
-        onChange={handleChange('name')}
-        value={state.name}
-        onValueUpdated={value => setState(s => ({ ...s, name: value }))}
-      />
-      <KeyValueEditorAccordion
-        title="Annotations"
-        expanded={expanded === 'annotations'}
-        onChange={handleChange('annotations')}
-        keyValueObject={state.annotations}
-        onUpdatedKeyValueObject={data =>
-          setState(s => ({ ...s, annotations: data }))
-        }
-      />
-      <KeyValueEditorAccordion
-        title="Labels"
-        expanded={expanded === 'labels'}
-        onChange={handleChange('labels')}
-        keyValueObject={state.labels}
-        onUpdatedKeyValueObject={data =>
-          setState(s => ({ ...s, labels: data }))
-        }
+      <ResourceMetadataAccordion
+        clusterScopedResource
+        expanded={expanded === 'metadata'}
+        onChange={handleChange('metadata')}
+        value={state}
+        onUpdate={v => {
+          setState(s => ({ ...s, ...v }));
+        }}
       />
     </div>
   );

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/ServiceAccountEditor/ServiceAccountEditor.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/ServiceAccountEditor/ServiceAccountEditor.tsx
@@ -18,8 +18,7 @@ import React, { ChangeEvent, useEffect, useState } from 'react';
 import { KubernetesKeyValueObject } from '../../../../../types/KubernetesResource';
 import { ServiceAccount } from '../../../../../types/ServiceAccount';
 import { dumpYaml, loadYaml } from '../../../../../utils/yaml';
-import { KeyValueEditorAccordion } from '../Controls/KeyValueEditorAccordion';
-import { SingleTextFieldAccordion } from '../Controls/SingleTextFieldAccordion';
+import { ResourceMetadataAccordion } from '../Controls/ResourceMetadataAccordion';
 import { useEditorStyles } from '../styles';
 
 type OnUpdatedYamlFn = (yaml: string) => void;
@@ -31,9 +30,9 @@ type ResourceEditorProps = {
 
 type State = {
   name: string;
-  namespace: string;
-  annotations: KubernetesKeyValueObject;
-  labels: KubernetesKeyValueObject;
+  namespace?: string;
+  annotations?: KubernetesKeyValueObject;
+  labels?: KubernetesKeyValueObject;
 };
 
 export const ServiceAccountEditor = ({
@@ -44,9 +43,9 @@ export const ServiceAccountEditor = ({
 
   const createResourceState = (): State => ({
     name: resourceYaml.metadata.name,
-    annotations: resourceYaml.metadata.annotations ?? {},
-    labels: resourceYaml.metadata.labels ?? {},
-    namespace: resourceYaml.metadata.namespace ?? '',
+    annotations: resourceYaml.metadata.annotations,
+    labels: resourceYaml.metadata.labels,
+    namespace: resourceYaml.metadata.namespace,
   });
 
   const [state, setState] = useState<State>(createResourceState());
@@ -61,53 +60,22 @@ export const ServiceAccountEditor = ({
 
   useEffect(() => {
     resourceYaml.metadata.name = state.name;
-    resourceYaml.metadata.namespace = state.namespace || undefined;
+    resourceYaml.metadata.namespace = state.namespace;
     resourceYaml.metadata.labels = state.labels;
     resourceYaml.metadata.annotations = state.annotations;
-
-    if (state.annotations && Object.keys(state.annotations).length === 0) {
-      delete resourceYaml.metadata.annotations;
-    }
-    if (state.labels && Object.keys(state.labels).length === 0) {
-      delete resourceYaml.metadata.labels;
-    }
 
     onUpdatedYaml(dumpYaml(resourceYaml));
   }, [state, onUpdatedYaml, resourceYaml]);
 
   return (
     <div className={classes.root}>
-      <SingleTextFieldAccordion
-        title="Name"
-        expanded={expanded === 'name'}
-        onChange={handleChange('name')}
-        value={state.name}
-        onValueUpdated={value => setState(s => ({ ...s, name: value }))}
-      />
-      <SingleTextFieldAccordion
-        title="Namespace"
-        expanded={expanded === 'namespace'}
-        onChange={handleChange('namespace')}
-        value={state.namespace}
-        onValueUpdated={value => setState(s => ({ ...s, namespace: value }))}
-      />
-      <KeyValueEditorAccordion
-        title="Annotations"
-        expanded={expanded === 'annotations'}
-        onChange={handleChange('annotations')}
-        keyValueObject={state.annotations}
-        onUpdatedKeyValueObject={data =>
-          setState(s => ({ ...s, annotations: data }))
-        }
-      />
-      <KeyValueEditorAccordion
-        title="Labels"
-        expanded={expanded === 'labels'}
-        onChange={handleChange('labels')}
-        keyValueObject={state.labels}
-        onUpdatedKeyValueObject={data =>
-          setState(s => ({ ...s, labels: data }))
-        }
+      <ResourceMetadataAccordion
+        expanded={expanded === 'metadata'}
+        onChange={handleChange('metadata')}
+        value={state}
+        onUpdate={v => {
+          setState(s => ({ ...s, ...v }));
+        }}
       />
     </div>
   );

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/ServiceEditor/ServiceEditor.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/ServiceEditor/ServiceEditor.tsx
@@ -32,8 +32,7 @@ import { sortByLabel } from '../../../../../utils/selectItem';
 import { dumpYaml, loadYaml } from '../../../../../utils/yaml';
 import { Select } from '../../../../Controls/Select';
 import { EditorAccordion } from '../Controls/EditorAccordion';
-import { KeyValueEditorAccordion } from '../Controls/KeyValueEditorAccordion';
-import { SingleTextFieldAccordion } from '../Controls/SingleTextFieldAccordion';
+import { ResourceMetadataAccordion } from '../Controls/ResourceMetadataAccordion';
 import { useEditorStyles } from '../styles';
 import { ServicePortEditorAccordion } from './components/ServicePortEditorAccordion';
 
@@ -47,9 +46,9 @@ type ServiceEditorProps = {
 
 type State = {
   name: string;
-  namespace: string;
-  annotations: KubernetesKeyValueObject;
-  labels: KubernetesKeyValueObject;
+  namespace?: string;
+  annotations?: KubernetesKeyValueObject;
+  labels?: KubernetesKeyValueObject;
   type: string;
   selector: string;
   externalTrafficPolicy: string;
@@ -112,9 +111,9 @@ export const ServiceEditor = ({
 
   const createResourceState = (): State => ({
     name: resourceYaml.metadata.name,
-    annotations: resourceYaml.metadata.annotations ?? {},
-    labels: resourceYaml.metadata.labels ?? {},
-    namespace: resourceYaml.metadata.namespace ?? '',
+    annotations: resourceYaml.metadata.annotations,
+    labels: resourceYaml.metadata.labels,
+    namespace: resourceYaml.metadata.namespace,
     selector:
       (workloadSelectItems.find(
         s =>
@@ -172,7 +171,7 @@ export const ServiceEditor = ({
       omit(servicePortView, servicePortOmitKeys);
 
     resourceYaml.metadata.name = state.name;
-    resourceYaml.metadata.namespace = state.namespace || undefined;
+    resourceYaml.metadata.namespace = state.namespace;
     resourceYaml.metadata.labels = state.labels;
     resourceYaml.metadata.annotations = state.annotations;
     resourceYaml.spec.type = state.type;
@@ -189,13 +188,6 @@ export const ServiceEditor = ({
     resourceYaml.spec.externalName = isExternalNameRelevant
       ? state.externalName
       : undefined;
-
-    if (state.annotations && Object.keys(state.annotations).length === 0) {
-      delete resourceYaml.metadata.annotations;
-    }
-    if (state.labels && Object.keys(state.labels).length === 0) {
-      delete resourceYaml.metadata.labels;
-    }
 
     onUpdatedYaml(dumpYaml(resourceYaml));
   }, [
@@ -232,38 +224,15 @@ export const ServiceEditor = ({
 
   return (
     <div className={classes.root}>
-      <SingleTextFieldAccordion
-        title="Name"
-        expanded={expanded === 'name'}
-        onChange={handleChange('name')}
-        value={state.name}
-        onValueUpdated={value => setState(s => ({ ...s, name: value }))}
+      <ResourceMetadataAccordion
+        expanded={expanded === 'metadata'}
+        onChange={handleChange('metadata')}
+        value={state}
+        onUpdate={v => {
+          setState(s => ({ ...s, ...v }));
+        }}
       />
-      <SingleTextFieldAccordion
-        title="Namespace"
-        expanded={expanded === 'namespace'}
-        onChange={handleChange('namespace')}
-        value={state.namespace}
-        onValueUpdated={value => setState(s => ({ ...s, namespace: value }))}
-      />
-      <KeyValueEditorAccordion
-        title="Annotations"
-        expanded={expanded === 'annotations'}
-        onChange={handleChange('annotations')}
-        keyValueObject={state.annotations}
-        onUpdatedKeyValueObject={data =>
-          setState(s => ({ ...s, annotations: data }))
-        }
-      />
-      <KeyValueEditorAccordion
-        title="Labels"
-        expanded={expanded === 'labels'}
-        onChange={handleChange('labels')}
-        keyValueObject={state.labels}
-        onUpdatedKeyValueObject={data =>
-          setState(s => ({ ...s, labels: data }))
-        }
-      />
+
       <EditorAccordion
         title="Service"
         description={getServiceDescription()}

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/SetLabelsEditor/SetLabelsEditor.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/SetLabelsEditor/SetLabelsEditor.tsx
@@ -19,7 +19,7 @@ import { KubernetesKeyValueObject } from '../../../../../types/KubernetesResourc
 import { SetLabels } from '../../../../../types/SetLabels';
 import { dumpYaml, loadYaml } from '../../../../../utils/yaml';
 import { KeyValueEditorAccordion } from '../Controls/KeyValueEditorAccordion';
-import { SingleTextFieldAccordion } from '../Controls/SingleTextFieldAccordion';
+import { ResourceMetadataAccordion } from '../Controls/ResourceMetadataAccordion';
 import { useEditorStyles } from '../styles';
 
 type OnUpdatedYamlFn = (yaml: string) => void;
@@ -31,8 +31,8 @@ type ResourceEditorProps = {
 
 type State = {
   name: string;
-  annotations: KubernetesKeyValueObject;
-  labels: KubernetesKeyValueObject;
+  annotations?: KubernetesKeyValueObject;
+  labels?: KubernetesKeyValueObject;
   setLabels: KubernetesKeyValueObject;
 };
 
@@ -44,8 +44,8 @@ export const SetLabelsEditor = ({
 
   const createResourceState = (): State => ({
     name: resourceYaml.metadata.name,
-    annotations: resourceYaml.metadata.annotations ?? {},
-    labels: resourceYaml.metadata.labels ?? {},
+    annotations: resourceYaml.metadata.annotations,
+    labels: resourceYaml.metadata.labels,
     setLabels: resourceYaml.labels,
   });
 
@@ -65,43 +65,21 @@ export const SetLabelsEditor = ({
     resourceYaml.metadata.annotations = state.annotations;
     resourceYaml.labels = state.setLabels;
 
-    if (state.annotations && Object.keys(state.annotations).length === 0) {
-      delete resourceYaml.metadata.annotations;
-    }
-    if (state.labels && Object.keys(state.labels).length === 0) {
-      delete resourceYaml.metadata.labels;
-    }
-
     onUpdatedYaml(dumpYaml(resourceYaml));
   }, [state, resourceYaml, onUpdatedYaml]);
 
   return (
     <div className={classes.root}>
-      <SingleTextFieldAccordion
-        title="Name"
-        expanded={expanded === 'name'}
-        onChange={handleChange('name')}
-        value={state.name}
-        onValueUpdated={value => setState(s => ({ ...s, name: value }))}
+      <ResourceMetadataAccordion
+        clusterScopedResource
+        expanded={expanded === 'metadata'}
+        onChange={handleChange('metadata')}
+        value={state}
+        onUpdate={v => {
+          setState(s => ({ ...s, ...v }));
+        }}
       />
-      <KeyValueEditorAccordion
-        title="Annotations"
-        expanded={expanded === 'annotations'}
-        onChange={handleChange('annotations')}
-        keyValueObject={state.annotations}
-        onUpdatedKeyValueObject={data =>
-          setState(s => ({ ...s, annotations: data }))
-        }
-      />
-      <KeyValueEditorAccordion
-        title="Labels"
-        expanded={expanded === 'labels'}
-        onChange={handleChange('labels')}
-        keyValueObject={state.labels}
-        onUpdatedKeyValueObject={data =>
-          setState(s => ({ ...s, labels: data }))
-        }
-      />
+
       <KeyValueEditorAccordion
         title="Set Labels"
         expanded={expanded === 'set-labels'}


### PR DESCRIPTION
This change updates the resource editors so the resource's name, namespace, labels, and annotations now appear within the Resources Metadata group.