### PR TITLE
feat: allow ingress resource to be added

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
@@ -102,6 +102,11 @@ export const PackageRevisionResourcesTable = ({
       k8LocalConfig: true,
     },
     {
+      apiVersion: 'networking.k8s.io/v1',
+      kind: 'Ingress',
+      namespaceScoped: true,
+    },
+    {
       apiVersion: 'v1',
       kind: 'ConfigMap',
       namespaceScoped: true,


### PR DESCRIPTION
This change updates the Package Revision page to allow an Ingress resource to be added to a package.