### PR TITLE
feat: add local config indicator to resources table

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
@@ -19,6 +19,7 @@ import { errorApiRef, useApi } from '@backstage/core-plugin-api';
 import { Button, Divider, Menu, MenuItem } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import DeleteIcon from '@material-ui/icons/Delete';
+import SettingsIcon from '@material-ui/icons/Settings';
 import { cloneDeep, startCase } from 'lodash';
 import React, { Fragment, useRef, useState } from 'react';
 import {
@@ -167,7 +168,23 @@ export const PackageRevisionResourcesTable = ({
     }
   };
 
-  const renderRowOptions = (resourceRow: ResourceRow): JSX.Element[] => {
+  const renderLocalConfigColumn = (
+    resourceRow: ResourceRow,
+  ): JSX.Element | null => {
+    if (resourceRow.isLocalConfigResource) {
+      return (
+        <Fragment>
+          <IconButton title="Local config" inTable>
+            <SettingsIcon />
+          </IconButton>
+        </Fragment>
+      );
+    }
+
+    return null;
+  };
+
+  const renderOptionsColumn = (resourceRow: ResourceRow): JSX.Element[] => {
     const options: JSX.Element[] = [];
 
     if (isEditMode && !resourceRow.isDeleted) {
@@ -216,11 +233,12 @@ export const PackageRevisionResourcesTable = ({
   };
 
   const columns: TableColumn<ResourceRow>[] = [
+    { render: renderLocalConfigColumn, width: 'min-content' },
     { title: 'Kind', field: 'kind' },
     { title: 'Name', field: 'name' },
     { title: 'Namespace', field: 'namespace' },
     {},
-    { render: resourceRow => <div>{renderRowOptions(resourceRow)}</div> },
+    { render: resourceRow => <div>{renderOptionsColumn(resourceRow)}</div> },
   ];
 
   if (showDiff) {

--- a/plugins/cad/src/utils/packageRevisionResources.ts
+++ b/plugins/cad/src/utils/packageRevisionResources.ts
@@ -36,6 +36,7 @@ export type PackageResource = {
   yaml: string;
   filename: string;
   resourceIndex: number;
+  isLocalConfigResource: boolean;
 };
 
 export enum ResourceDiffStatus {
@@ -134,6 +135,10 @@ export const getPackageResourcesFromResourcesMap = (
         namespace: k8sResource.metadata.namespace,
         yaml: resourceYaml,
         resourceIndex: index,
+        isLocalConfigResource:
+          !!k8sResource.metadata.annotations?.[
+            'config.kubernetes.io/local-config'
+          ],
       };
     });
   });


### PR DESCRIPTION
This change adds a visual indicator to local config resources in the Resources table.