### PR TITLE
feat: update add resource default namespace logic

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
@@ -273,7 +273,8 @@ export const PackageRevisionResourcesTable = ({
       resourceGVK;
 
     const getNamespace = (): string | undefined =>
-      resources.find(r => r.kind === 'Namespace')?.name;
+      resources.find(r => r.kind === 'Namespace')?.name ||
+      resources.find(r => r.namespace)?.namespace;
 
     const name = defaultName || 'default';
     const namespace = namespaceScoped ? getNamespace() : undefined;


### PR DESCRIPTION
This change updates the Add Resource button on the Package Revision page to default the namespace of the new resource to the namespace other resources within the package are using if a namespace resource does not exist.