### PR TITLE
feat: update repositories list on landing page

### DIFF
--- a/plugins/cad/src/utils/repositorySummary.ts
+++ b/plugins/cad/src/utils/repositorySummary.ts
@@ -98,12 +98,3 @@ export const populatePackageSummaries = (
     );
   });
 };
-
-export const fitlerRepositorySummary = (
-  repositorySummaries: RepositorySummary[],
-  repositoryFilter: (repository: Repository) => boolean,
-): RepositorySummary[] => {
-  return repositorySummaries.filter(summary =>
-    repositoryFilter(summary.repository),
-  );
-};


### PR DESCRIPTION
This change updates the Landing Page eliminating the tabs and having separate tables for each repository content type.