### PR TITLE
fix: use unique resources table column for diff

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
@@ -237,12 +237,18 @@ export const PackageRevisionResourcesTable = ({
     { title: 'Kind', field: 'kind' },
     { title: 'Name', field: 'name' },
     { title: 'Namespace', field: 'namespace' },
-    {},
+    { title: 'Diff', render: renderDiffColumn },
     { render: resourceRow => <div>{renderOptionsColumn(resourceRow)}</div> },
   ];
 
-  if (showDiff) {
-    columns[3] = { title: 'Diff', render: renderDiffColumn };
+  if (!showDiff) {
+    const diffColumn = columns.find(column => column.title === 'Diff');
+
+    if (!diffColumn) {
+      throw new Error('Diff column not found');
+    }
+
+    columns[columns.indexOf(diffColumn)] = {};
   }
 
   const saveUpdatedYaml = (yaml: string): void => {


### PR DESCRIPTION
This change ensures that a unique column will always be used for diff on the Resources Table. 