### PR TITLE
feat: update resource editor to show yaml when no named editor exists

### DIFF
--- a/plugins/cad/src/components/ResourceEditorDialog/ResourceEditorDialog.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/ResourceEditorDialog.tsx
@@ -22,7 +22,7 @@ import {
   DialogTitle,
   makeStyles,
 } from '@material-ui/core';
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { KubernetesResource } from '../../types/KubernetesResource';
 import { PackageResource } from '../../utils/packageRevisionResources';
 import { loadYaml } from '../../utils/yaml';
@@ -60,6 +60,7 @@ export const ResourceEditorDialog = ({
 
   const [showYamlView, setShowYamlView] = useState<boolean>(false);
   const [latestYaml, setLatestYaml] = useState<string>('');
+  const [isNamedEditor, setIsNamedEditor] = useState<boolean>(true);
 
   const resourceYaml = loadYaml(yaml) as KubernetesResource;
 
@@ -71,12 +72,15 @@ export const ResourceEditorDialog = ({
       // Reset the state of the dialog anytime it is opened
       setLatestYaml(yaml);
       setShowYamlView(false);
+      setIsNamedEditor(true);
     }
   }, [open, yaml]);
 
   const toggleView = (): void => {
     setShowYamlView(!showYamlView);
   };
+
+  const handleNoNamedEditor = useCallback(() => setIsNamedEditor(false), []);
 
   const handleUpdatedYaml = (updatedYaml: string): void => {
     setLatestYaml(updatedYaml);
@@ -105,12 +109,13 @@ export const ResourceEditorDialog = ({
             className={classes.container}
             style={{ height: `${latestYamlHeight}px` }}
           >
-            {!showYamlView ? (
+            {!showYamlView && isNamedEditor ? (
               <FirstClassEditorSelector
                 apiVersion={resourceApiVersion}
                 kind={kind}
                 yaml={latestYaml}
                 packageResources={packageResources}
+                onNoNamedEditor={handleNoNamedEditor}
                 onUpdatedYaml={handleUpdatedYaml}
               />
             ) : (
@@ -121,9 +126,11 @@ export const ResourceEditorDialog = ({
               />
             )}
           </div>
-          <Button variant="text" color="primary" onClick={toggleView}>
-            Show {showYamlView ? 'Formatted View' : 'YAML View'}
-          </Button>
+          {isNamedEditor && (
+            <Button variant="text" color="primary" onClick={toggleView}>
+              Show {showYamlView ? 'Formatted View' : 'YAML View'}
+            </Button>
+          )}
         </Fragment>
       </DialogContent>
       <DialogActions>

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditorSelector.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditorSelector.tsx
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Typography } from '@material-ui/core';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { PackageResource } from '../../../utils/packageRevisionResources';
 import { ApplyReplacementsEditor } from './FirstClassEditors/ApplyReplacementsEditor';
 import { ConfigMapEditor } from './FirstClassEditors/ConfigMapEditor';
@@ -30,12 +29,14 @@ import { ServiceEditor } from './FirstClassEditors/ServiceEditor';
 import { SetLabelsEditor } from './FirstClassEditors/SetLabelsEditor';
 
 type OnUpdatedYamlFn = (yaml: string) => void;
+type OnNoNamedEditorFn = () => void;
 
 type FirstClassEditorSelectorProps = {
   apiVersion: string;
   kind: string;
   yaml: string;
   onUpdatedYaml: OnUpdatedYamlFn;
+  onNoNamedEditor: OnNoNamedEditorFn;
   packageResources: PackageResource[];
 };
 
@@ -44,9 +45,17 @@ export const FirstClassEditorSelector = ({
   kind,
   yaml,
   onUpdatedYaml,
+  onNoNamedEditor,
   packageResources,
 }: FirstClassEditorSelectorProps) => {
   const groupVersionKind = `${apiVersion}/${kind}`;
+  const isNamedEditor = useRef<boolean>(true);
+
+  useEffect(() => {
+    if (!isNamedEditor.current) {
+      onNoNamedEditor();
+    }
+  }, [onNoNamedEditor]);
 
   switch (groupVersionKind) {
     case 'fn.kpt.dev/v1alpha1/ApplyReplacements':
@@ -115,12 +124,6 @@ export const FirstClassEditorSelector = ({
     default:
   }
 
-  return (
-    <div>
-      <Typography>
-        A first class editor could not be found for {kind}. Use the YAML VIEW to
-        update the resource's YAML directly.
-      </Typography>
-    </div>
-  );
+  isNamedEditor.current = false;
+  return null;
 };


### PR DESCRIPTION
This change updates the Resource Editor Dialog to show the yaml editor on open when a named resource editor does not exist.