### PR TITLE
feat: update upstream package logic

### DIFF
--- a/plugins/cad/src/utils/packageRevision.ts
+++ b/plugins/cad/src/utils/packageRevision.ts
@@ -63,9 +63,16 @@ export const getUpstreamPackageRevisionDetails = (
 
   if (upstreamLock?.git) {
     const repositoryUrl = upstreamLock.git.repo;
-    const [packageName, revision] = upstreamLock.git.ref.split('/');
 
-    return { repositoryUrl, packageName, revision };
+    const upstreamRef = upstreamLock.git.ref;
+    const separatorIdx = upstreamRef.lastIndexOf('/');
+
+    if (separatorIdx > 0) {
+      const packageName = upstreamRef.slice(0, separatorIdx);
+      const revision = upstreamRef.slice(separatorIdx + 1);
+
+      return { repositoryUrl, packageName, revision };
+    }
   }
 
   return undefined;

--- a/plugins/cad/src/utils/repository.ts
+++ b/plugins/cad/src/utils/repository.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { trimEnd } from 'lodash';
 import { KubernetesKeyValueObject } from '../types/KubernetesResource';
 import {
   Repository,
@@ -163,8 +164,12 @@ export const findRepository = (
   { repositoryUrl }: { repositoryUrl?: string },
 ): Repository | undefined => {
   if (repositoryUrl) {
+    const normalize = (repository?: string): string =>
+      trimEnd(repository, '.git');
+
     return allRepositories.find(
-      repository => repository.spec.git?.repo === repositoryUrl,
+      repository =>
+        normalize(repository.spec.git?.repo) === normalize(repositoryUrl),
     );
   }
 


### PR DESCRIPTION
This change updates the upstream package revision logic increasing flexibility with the git repository match and only returning upstream information if the package name and revision delimiter is found within the upstream lock git reference.