### PR TITLE
feat: add content type descriptions to register repository page

### DIFF
--- a/plugins/cad/src/components/Controls/RadioGroup.tsx
+++ b/plugins/cad/src/components/Controls/RadioGroup.tsx
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  FormLabel,
+  makeStyles,
+  Radio,
+  RadioGroup as MaterialRadioGroup,
+} from '@material-ui/core';
+import { snakeCase } from 'lodash';
+import React, { Fragment } from 'react';
+
+export type RadioOption = {
+  label: string;
+  value: string;
+  description?: string;
+};
+
+type RadioGroupProps = {
+  label: string;
+  value: string;
+  options: RadioOption[];
+  onChange: (value: string) => void;
+  helperText?: string;
+};
+
+const useStyles = makeStyles({
+  optionDescription: {
+    marginBottom: '14px',
+    marginLeft: '32px',
+    marginTop: '0',
+  },
+});
+
+export const RadioGroup = ({
+  label,
+  value,
+  options,
+  onChange,
+  helperText,
+}: RadioGroupProps) => {
+  const classes = useStyles();
+
+  const labelId = `label-${snakeCase(label)}`;
+
+  return (
+    <FormControl>
+      <FormLabel id={labelId}>{label}</FormLabel>
+      <FormHelperText>{helperText}</FormHelperText>
+      <MaterialRadioGroup
+        aria-labelledby={labelId}
+        value={value}
+        onChange={e => onChange((e.target as HTMLInputElement).value)}
+      >
+        {options.map(option => (
+          <Fragment>
+            <FormControlLabel
+              key={option.value}
+              value={option.value}
+              control={<Radio color="primary" />}
+              label={option.label}
+            />
+
+            {option.description && (
+              <FormHelperText className={classes.optionDescription}>
+                {option.description}
+              </FormHelperText>
+            )}
+          </Fragment>
+        ))}
+      </MaterialRadioGroup>
+    </FormControl>
+  );
+};

--- a/plugins/cad/src/components/Controls/index.ts
+++ b/plugins/cad/src/components/Controls/index.ts
@@ -19,5 +19,7 @@ export { ConfirmationDialog } from './ConfirmationDialog';
 export { IconButton } from './IconButton';
 export { MultiSelect } from './MultiSelect';
 export { PackageIcon } from './PackageIcon';
+export { RadioGroup } from './RadioGroup';
+export type { RadioOption } from './RadioGroup';
 export { Select } from './Select';
 export { YamlViewer } from './YamlViewer';

--- a/plugins/cad/src/components/RegisterRepositoryPage/RegisterRepositoryPage.tsx
+++ b/plugins/cad/src/components/RegisterRepositoryPage/RegisterRepositoryPage.tsx
@@ -45,9 +45,10 @@ import {
   getRepositoryResource,
   getSecretRef,
   PackageContentSummaryOrder,
+  RepositoryContentDetails,
 } from '../../utils/repository';
 import { getBasicAuthSecret, isBasicAuthSecret } from '../../utils/secret';
-import { Select } from '../Controls/Select';
+import { RadioGroup, RadioOption, Select } from '../Controls';
 import { RepositoriesLink } from '../Links';
 
 const useStyles = makeStyles(() => ({
@@ -264,11 +265,12 @@ export const RegisterRepositoryPage = () => {
     updateStateValue(target.name, target.value);
   };
 
-  const repositoryContentSelectItems = useMemo(() => {
-    const selectItems: SelectItem[] = PackageContentSummaryOrder.map(
+  const repositoryContentRadioOptions = useMemo(() => {
+    const selectItems: RadioOption[] = PackageContentSummaryOrder.map(
       contentType => ({
         label: `${contentType}s`,
         value: contentType,
+        description: RepositoryContentDetails[contentType].description,
       }),
     );
 
@@ -276,6 +278,8 @@ export const RegisterRepositoryPage = () => {
       selectItems.push({
         label: 'Functions',
         value: ContentSummary.FUNCTION,
+        description:
+          RepositoryContentDetails[ContentSummary.FUNCTION].description,
       });
     }
 
@@ -425,11 +429,11 @@ export const RegisterRepositoryPage = () => {
 
         <SimpleStepperStep title="Repository Content">
           <div className={classes.stepContent}>
-            <Select
-              label="Content"
+            <RadioGroup
+              label="Repository Content"
               onChange={value => updateStateValue('contentSummary', value)}
-              selected={state.contentSummary}
-              items={repositoryContentSelectItems}
+              value={state.contentSummary}
+              options={repositoryContentRadioOptions}
               helperText="The content the repository will store."
             />
           </div>

--- a/plugins/cad/src/utils/repository.ts
+++ b/plugins/cad/src/utils/repository.ts
@@ -31,6 +31,7 @@ type ContentDetails = {
 
 type ContentDetail = {
   repositoryContent: RepositoryContent;
+  description: string;
   isDeployment?: boolean;
   repositoryContentLabelValue?: string;
   notContent?: ContentSummary[];
@@ -69,11 +70,15 @@ export const isDeploymentRepository = (repository: Repository): boolean => {
 export const RepositoryContentDetails: ContentDetails = {
   [ContentSummary.DEPLOYMENT]: {
     repositoryContent: RepositoryContent.PACKAGE,
+    description:
+      'Deployment Packages are packages ready for deployment to live clusters.',
     isDeployment: true,
     cloneTo: [],
   },
   [ContentSummary.TEAM_BLUEPRINT]: {
     repositoryContent: RepositoryContent.PACKAGE,
+    description:
+      'Team Blueprints are packages that a team in your organization owns. Deployment Packages can be created from packages in this repository.',
     notContent: [
       ContentSummary.ORGANIZATIONAL_BLUEPRINT,
       ContentSummary.EXTERNAL_BLUEPRINT,
@@ -83,6 +88,8 @@ export const RepositoryContentDetails: ContentDetails = {
   [ContentSummary.ORGANIZATIONAL_BLUEPRINT]: {
     repositoryContent: RepositoryContent.PACKAGE,
     repositoryContentLabelValue: 'organizational-blueprints',
+    description:
+      'Organizational Blueprints are packages that your organization owns. An Organizational Blueprint package is expected to be cloned and customized in a Team Blueprint repository before a Deployment Package is created.',
     cloneTo: [
       ContentSummary.DEPLOYMENT,
       ContentSummary.TEAM_BLUEPRINT,
@@ -92,6 +99,8 @@ export const RepositoryContentDetails: ContentDetails = {
   [ContentSummary.EXTERNAL_BLUEPRINT]: {
     repositoryContent: RepositoryContent.PACKAGE,
     repositoryContentLabelValue: 'external-blueprints',
+    description:
+      'External Blueprints are packages that your organization does not own. An External Blueprint package is expected to be cloned and customized in an Organization or Team Blueprint repository before a Deployment Package is created.',
     cloneTo: [
       ContentSummary.DEPLOYMENT,
       ContentSummary.TEAM_BLUEPRINT,
@@ -101,6 +110,8 @@ export const RepositoryContentDetails: ContentDetails = {
   },
   [ContentSummary.FUNCTION]: {
     repositoryContent: RepositoryContent.FUNCTION,
+    description:
+      'Functions are containerized programs that can perform CRUD operations on KRM resources.',
     cloneTo: [],
   },
 };


### PR DESCRIPTION
This change updates the Register Repository Page adding descriptions to the repository content types.