### PR TITLE
feat: create git repository branch if it does not exist

### DIFF
--- a/plugins/cad/src/components/RegisterRepositoryPage/RegisterRepositoryPage.tsx
+++ b/plugins/cad/src/components/RegisterRepositoryPage/RegisterRepositoryPage.tsx
@@ -135,9 +135,12 @@ export const RegisterRepositoryPage = () => {
     let ociDetails: RepositoryOciDetails | undefined = undefined;
 
     if (state.type === RepositoryType.GIT) {
+      const createBranch = true;
+
       gitDetails = getRepositoryGitDetails(
         state.repoUrl,
         state.repoBranch || 'main',
+        createBranch,
         state.repoDir || '/',
         secretRef,
       );

--- a/plugins/cad/src/types/Repository.ts
+++ b/plugins/cad/src/types/Repository.ts
@@ -57,6 +57,7 @@ export enum RepositoryContent {
 export type RepositoryGitDetails = {
   repo: string;
   branch: string;
+  createBranch?: boolean;
   directory: string;
   secretRef?: RepositorySecretRef;
 };

--- a/plugins/cad/src/utils/repository.ts
+++ b/plugins/cad/src/utils/repository.ts
@@ -234,12 +234,14 @@ export const getRepositoryResource = (
 export const getRepositoryGitDetails = (
   repo: string,
   branch: string,
+  createBranch: boolean,
   directory: string,
   secretRef: RepositorySecretRef | undefined,
 ): RepositoryGitDetails => {
   const gitDetails: RepositoryGitDetails = {
     repo,
     branch,
+    createBranch,
     directory,
     secretRef,
   };


### PR DESCRIPTION
This change updates the Register Repository Page to request Porch to create the git repository branch if it does not exist.