### PR TITLE
fix: update resource editor title when showing a new resource

### DIFF
--- a/plugins/cad/src/components/ResourceEditorDialog/ResourceEditorDialog.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/ResourceEditorDialog.tsx
@@ -96,9 +96,10 @@ export const ResourceEditorDialog = ({
   };
 
   const latestYamlHeight = (latestYaml.split('\n').length + 1) * 18;
-  const title = resourceYaml?.metadata
-    ? `${resourceYaml.kind} ${resourceYaml?.metadata.name}`
-    : 'New Resource';
+  const title =
+    resourceYaml?.kind && resourceYaml?.metadata
+      ? `${resourceYaml.kind} ${resourceYaml?.metadata.name}`
+      : 'New Resource';
 
   return (
     <Dialog open={open} onClose={onDialogClose} maxWidth="lg">


### PR DESCRIPTION
This change updates the title of the Resource Editor Dialog to 'New Resource' when the dialog is opened for a new resource.