### PR TITLE
feat: update resources table to show local config resources first

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageResourcesList.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageResourcesList.tsx
@@ -56,7 +56,7 @@ const sortResources = (allResources: ResourceRow[]): void => {
   allResources.sort((resource1, resource2) => {
     const resourceScore = (resource: ResourceRow): number => {
       if (resource.kind === 'Kptfile') return 1000;
-      if (resource.kind === 'Namespace') return 100;
+      if (resource.isLocalConfigResource) return 100;
 
       return 0;
     };


### PR DESCRIPTION
This change updates the Resources Table to show resources with the config.kubernetes.io/local-config annotation first.