### PR TITLE
fix: update package upgrade available logic

### DIFF
--- a/plugins/cad/src/utils/packageSummary.ts
+++ b/plugins/cad/src/utils/packageSummary.ts
@@ -121,8 +121,9 @@ export const getPackageSummariesForRepository = (
             );
 
           thisPackageSummary.isUpgradeAvailable =
-            thisPackageSummary.upstreamLatestPublishedRevision?.spec
-              .revision !== upstream.revision;
+            thisPackageSummary.upstreamLatestPublishedRevision &&
+            thisPackageSummary.upstreamLatestPublishedRevision.spec.revision !==
+              upstream.revision;
         }
       }
 


### PR DESCRIPTION
This change updates the package upgrade available logic to ensure packages are not incorrectly flagged as upgrade available.