### PR TITLE
feat: allow kptfile information to be updated when cloning a package

### DIFF
--- a/plugins/cad/src/types/Kptfile.ts
+++ b/plugins/cad/src/types/Kptfile.ts
@@ -32,8 +32,9 @@ export type KptfileMetadata = {
 };
 
 export type KptfileInfo = {
-  description: string;
-  keywords: string[];
+  description?: string;
+  keywords?: string[];
+  site?: string;
 };
 
 export type KptfilePipeline = {

--- a/plugins/cad/src/utils/packageRevisionResources.ts
+++ b/plugins/cad/src/utils/packageRevisionResources.ts
@@ -298,3 +298,13 @@ export const diffPackageResources = (
 
   return diffSummary;
 };
+
+export const getRootKptfile = (
+  resources: PackageResource[],
+): PackageResource => {
+  const kptfileResource = resources.find(r => r.filename === 'Kptfile');
+
+  if (!kptfileResource) throw new Error('Kptfile not found');
+
+  return kptfileResource;
+};

--- a/plugins/cad/src/utils/string.ts
+++ b/plugins/cad/src/utils/string.ts
@@ -17,3 +17,7 @@
 export const toLowerCase = (str: string): string | undefined => {
   return str.toLocaleLowerCase('us-EN');
 };
+
+export const emptyIfUndefined = (str?: string): string => {
+  return str ?? '';
+};


### PR DESCRIPTION
This change updates the Add Package Page to allow the Kptfile description, keywords, and site to be updated when a package is being cloned.