### PR TITLE
feat: add validate resources step on add package page

### DIFF
--- a/plugins/cad/src/components/Controls/Checkbox.tsx
+++ b/plugins/cad/src/components/Controls/Checkbox.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Checkbox as MaterialCheckbox,
+  FormControlLabel,
+  FormHelperText,
+  makeStyles,
+} from '@material-ui/core';
+import React, { ChangeEvent } from 'react';
+
+type CheckboxProps = {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  helperText?: JSX.Element | string;
+};
+
+const useStyles = makeStyles({
+  description: {
+    marginLeft: '32px',
+    marginTop: '0',
+  },
+});
+
+export const Checkbox = ({
+  label,
+  checked,
+  onChange,
+  helperText,
+}: CheckboxProps) => {
+  const classes = useStyles();
+
+  return (
+    <div>
+      <FormControlLabel
+        control={<MaterialCheckbox checked={checked} color="primary" />}
+        label={label}
+        onChange={(_: ChangeEvent<{}>, isChecked: boolean) =>
+          onChange(isChecked)
+        }
+      />
+      {helperText && (
+        <FormHelperText className={classes.description}>
+          {helperText}
+        </FormHelperText>
+      )}
+    </div>
+  );
+};

--- a/plugins/cad/src/components/Controls/index.ts
+++ b/plugins/cad/src/components/Controls/index.ts
@@ -16,6 +16,7 @@
 
 export { Autocomplete } from './Autocomplete';
 export { ConfirmationDialog } from './ConfirmationDialog';
+export { Checkbox } from './Checkbox';
 export { IconButton } from './IconButton';
 export { MultiSelect } from './MultiSelect';
 export { PackageIcon } from './PackageIcon';

--- a/plugins/cad/src/utils/function.ts
+++ b/plugins/cad/src/utils/function.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { Function } from '../types/Function';
 import { groupBy } from 'lodash';
+import { Function } from '../types/Function';
+import { KptfileFunction } from '../types/Kptfile';
 
-type GroupFunctionsByName = {
+export type GroupFunctionsByName = {
   [key: string]: Function[];
 };
 
@@ -62,10 +63,30 @@ export const groupFunctionsByName = (
   return functionsGroupedByName;
 };
 
+export const getLatestFunction = (
+  functions: GroupFunctionsByName,
+  fnName: string,
+): Function => {
+  const fnGroup = functions[fnName];
+
+  if (!fnGroup) {
+    throw new Error(`Function ${fnName} not found`);
+  }
+
+  return fnGroup[0];
+};
+
 export const isMutatorFunction = (kptFunction: Function): boolean => {
   return kptFunction.spec.functionTypes.includes('mutator');
 };
 
 export const isValidatorFunction = (kptFunction: Function): boolean => {
   return kptFunction.spec.functionTypes.includes('validator');
+};
+
+export const findKptfileFunction = (
+  functions: KptfileFunction[],
+  fnName: string,
+): KptfileFunction | undefined => {
+  return functions.find(fn => getFunctionNameFromImage(fn.image) === fnName);
 };

--- a/plugins/cad/src/utils/packageRevisionResources.ts
+++ b/plugins/cad/src/utils/packageRevisionResources.ts
@@ -225,6 +225,39 @@ export const removeResourceFromResourcesMap = (
   return updatedResourcesMap;
 };
 
+export const updateResourcesMap = (
+  resourcesMap: PackageRevisionResourcesMap,
+  resourcesToAdd: PackageResource[],
+  resourcesToUpdate: PackageResource[],
+  resourcesToRemove: PackageResource[],
+): PackageRevisionResourcesMap => {
+  let newResourcesMap = resourcesMap;
+
+  for (const packageResource of resourcesToAdd) {
+    newResourcesMap = addResourceToResourcesMap(
+      newResourcesMap,
+      packageResource,
+    );
+  }
+
+  for (const packageResource of resourcesToUpdate) {
+    newResourcesMap = updateResourceInResourcesMap(
+      newResourcesMap,
+      packageResource,
+      packageResource.yaml,
+    );
+  }
+
+  for (const packageResource of resourcesToRemove) {
+    newResourcesMap = removeResourceFromResourcesMap(
+      newResourcesMap,
+      packageResource,
+    );
+  }
+
+  return newResourcesMap;
+};
+
 export const diffPackageResource = (
   originalResource?: PackageResource,
   currentResource?: PackageResource,


### PR DESCRIPTION
This change adds a Validate Resources step to the Add Package Page. This step allows users to have their package resources validated against their schema by adding the kubeval validator function to the Kptfile.