### PR TITLE
feat: add deployment environment to register repository page

### DIFF
--- a/plugins/cad/src/components/RepositoryPage/components/RepositoryDetails.tsx
+++ b/plugins/cad/src/components/RepositoryPage/components/RepositoryDetails.tsx
@@ -18,7 +18,11 @@ import { InfoCard, StructuredMetadataTable } from '@backstage/core-components';
 import React from 'react';
 import { Repository } from '../../../types/Repository';
 import { RepositorySummary } from '../../../types/RepositorySummary';
-import { getPackageDescriptor } from '../../../utils/repository';
+import {
+  getDeploymentEnvironment,
+  getPackageDescriptor,
+  isDeploymentRepository,
+} from '../../../utils/repository';
 
 type RepositoryDetailsProps = {
   repositorySummary: RepositorySummary;
@@ -60,8 +64,13 @@ const getRepositoryMetadata = (repository: Repository): Metadata => {
     name: repository.metadata.name,
     description: repository.spec.description ?? '',
     content: `${getPackageDescriptor(repository)}s`,
+    deploymentEnvironment: getDeploymentEnvironment(repository),
     ...getRepositoryStoreMetadata(repository),
   };
+
+  if (!isDeploymentRepository(repository)) {
+    delete metadata.deploymentEnvironment;
+  }
 
   return metadata;
 };


### PR DESCRIPTION
This change updates the Register Repository Page to request the deployment environment (development, staging, or production) when the repository content type is deployments.