### PR TITLE
feat: add git ssh url support for finding upstream repository

### DIFF
--- a/plugins/cad/src/utils/string.ts
+++ b/plugins/cad/src/utils/string.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export const toLowerCase = (str: string): string | undefined => {
+export const toLowerCase = (str: string): string => {
   return str.toLocaleLowerCase('us-EN');
 };
 


### PR DESCRIPTION
This change allows a package's upstream repository to be found if the package's upstream lock was based off an upstream that was fetched using ssh while the upstream repository in Porch was registered with https.