### PR TITLE
feat: update package revision page to normalize resources prior to diff

### DIFF
--- a/plugins/cad/src/utils/kubernetesResource.ts
+++ b/plugins/cad/src/utils/kubernetesResource.ts
@@ -1,0 +1,22 @@
+import { KubernetesResource } from '../types/KubernetesResource';
+
+export const removeInternalKptAnnotations = (
+  resource: KubernetesResource,
+): void => {
+  const resourceMetadata = resource.metadata;
+
+  if (resourceMetadata.annotations) {
+    const internalAnnotations = Object.keys(
+      resourceMetadata.annotations,
+    ).filter(annotation => annotation.startsWith('internal.kpt.dev/'));
+
+    internalAnnotations.forEach(
+      internalAnnotation =>
+        delete resourceMetadata.annotations?.[internalAnnotation],
+    );
+
+    if (Object.keys(resourceMetadata.annotations).length === 0) {
+      delete resourceMetadata.annotations;
+    }
+  }
+};

--- a/plugins/cad/src/utils/kubernetesResource.ts
+++ b/plugins/cad/src/utils/kubernetesResource.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { KubernetesResource } from '../types/KubernetesResource';
 
 export const removeInternalKptAnnotations = (


### PR DESCRIPTION
This change updates the Package Revision Page to normalize resources prior to the package revisions's resources being compared with another revision. Normalizing resources includes removing any internal kpt annotations, any comments, and standardizing the yaml indentation.