### PR TITLE
feat: allow deployment resource to be added

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
@@ -93,6 +93,11 @@ export const PackageRevisionResourcesTable = ({
 
   const addResourcesGVKs: KubernetesGKV[] = [
     {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      namespaceScoped: true,
+    },
+    {
       apiVersion: 'fn.kpt.dev/v1alpha1',
       kind: 'ApplyReplacements',
       k8LocalConfig: true,


### PR DESCRIPTION
This change updates the Package Revision page to allow a Deployment resource to be added to a package.