### PR TITLE
feat: allow stateful set resource to be added

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionResourcesTable.tsx
@@ -98,6 +98,11 @@ export const PackageRevisionResourcesTable = ({
       namespaceScoped: true,
     },
     {
+      apiVersion: 'apps/v1',
+      kind: 'StatefulSet',
+      namespaceScoped: true,
+    },
+    {
       apiVersion: 'fn.kpt.dev/v1alpha1',
       kind: 'ApplyReplacements',
       k8LocalConfig: true,


### PR DESCRIPTION
This change updates the Package Revision page to allow a Stateful Set resource to be added to a package.