### PR TITLE
feat: use porch workspace name

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionsTable.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionsTable.tsx
@@ -22,6 +22,7 @@ import { packageRouteRef } from '../../../routes';
 import { PackageRevisionLifecycle } from '../../../types/PackageRevision';
 import { Repository } from '../../../types/Repository';
 import { formatCreationTimestamp } from '../../../utils/formatDate';
+import { getPackageRevisionRevision } from '../../../utils/packageRevision';
 import {
   diffPackageResources,
   getPackageResourcesFromResourcesMap,
@@ -138,7 +139,7 @@ const mapToPackageRevisionRow = (
     id: revision.metadata.name,
     name: revision.metadata.name,
     packageName: revision.spec.packageName,
-    revision: revision.spec.revision,
+    revision: getPackageRevisionRevision(revision),
     lifecycle: revision.spec.lifecycle,
     created: creationTimestamp,
     resourcesCount: getPackageResourcesFromResourcesMap(resourcesMap).length,

--- a/plugins/cad/src/components/PackagesTable/PackagesTable.tsx
+++ b/plugins/cad/src/components/PackagesTable/PackagesTable.tsx
@@ -31,6 +31,7 @@ import { PackageLink, RepositoryLink } from '../Links';
 import { SyncStatusVisual } from './components/SyncStatusVisual';
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
 import { Repository } from '../../types/Repository';
+import { getPackageRevisionRevision } from '../../utils/packageRevision';
 
 type PackagesTableProps = {
   title: string;
@@ -174,7 +175,7 @@ const mapToUnpublishedRevision = (
     return {
       name: unpublishedRevision.metadata.name,
       packageName: unpublishedRevision.spec.packageName,
-      revision: unpublishedRevision.spec.revision,
+      revision: getPackageRevisionRevision(unpublishedRevision),
       lifecycle: unpublishedRevision.spec.lifecycle,
       created: formatCreationTimestamp(
         unpublishedRevision.metadata.creationTimestamp,
@@ -197,7 +198,7 @@ const mapToPackageSummaryRow = (
     id: onePackage.metadata.name,
     name: onePackage.metadata.name,
     packageName: onePackage.spec.packageName,
-    revision: onePackage.spec.revision,
+    revision: getPackageRevisionRevision(onePackage),
     lifecycle: onePackage.spec.lifecycle,
     syncStatus: getRootSyncStatus(packageSummary),
     created: formatCreationTimestamp(onePackage.metadata.creationTimestamp),

--- a/plugins/cad/src/types/PackageRevision.ts
+++ b/plugins/cad/src/types/PackageRevision.ts
@@ -34,7 +34,8 @@ export type PackageRevisionMetadata = {
 export type PackageRevisionSpec = {
   packageName: string;
   repository: string;
-  revision: string;
+  workspaceName?: string;
+  revision?: string;
   lifecycle: PackageRevisionLifecycle;
   tasks: PackageRevisionTask[];
 };


### PR DESCRIPTION
This change allows the UI to work with the latest version of Porch where workspace name is required to create new package revisions and revision numbers are not assigned until a package revision is published .