### PR TITLE
feat: add support for readonly repositories

### DIFF
--- a/plugins/cad/src/components/AddPackagePage/AddPackagePage.tsx
+++ b/plugins/cad/src/components/AddPackagePage/AddPackagePage.tsx
@@ -56,6 +56,7 @@ import {
   ContentSummary,
   getPackageDescriptor,
   getRepository,
+  isReadOnlyRepository,
   RepositoryContentDetails,
 } from '../../utils/repository';
 import { sortByLabel } from '../../utils/selectItem';
@@ -553,6 +554,15 @@ export const AddPackagePage = ({ action }: AddPackagePageProps) => {
                   items={targetRepositorySelectItems}
                   helperText={`The repository to create the new ${targetRepositoryPackageDescriptorLowercase} in.`}
                 />
+
+                {!!targetRepository && isReadOnlyRepository(targetRepository) && (
+                  <Alert severity="info" icon={false}>
+                    A new {targetRepositoryPackageDescriptorLowercase} cannot be
+                    created in the {targetRepository.metadata.name} repository
+                    since the repository is read-only. Another destination
+                    repository will need to be selected.
+                  </Alert>
+                )}
 
                 {!!addPackageAction?.message && (
                   <Alert severity="info" icon={false}>

--- a/plugins/cad/src/components/PackageRevisionPage/PackageRevisionPage.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/PackageRevisionPage.tsx
@@ -74,6 +74,7 @@ import {
   findRepository,
   getPackageDescriptor,
   isDeploymentRepository,
+  isReadOnlyRepository,
 } from '../../utils/repository';
 import {
   getRepositorySummaries,
@@ -819,7 +820,23 @@ export const PackageRevisionPage = ({ mode }: PackageRevisionPageProps) => {
     return upgradeMessage;
   };
 
-  const alertMessages = isUpgradeAvailable ? [getUpgradeMessage()] : [];
+  const alertMessages: AlertMessage[] = [];
+
+  if (isReadOnlyRepository(repository)) {
+    alertMessages.push({
+      key: 'read-only',
+      message: (
+        <Fragment>
+          This {toLowerCase(packageDescriptor)} is read-only since this{' '}
+          {toLowerCase(packageDescriptor)} exists in a read-only repository.
+        </Fragment>
+      ),
+    });
+  }
+
+  if (isUpgradeAvailable) {
+    alertMessages.push(getUpgradeMessage());
+  }
 
   if (isLatestPublishedPackageRevision) {
     const downstreamPackagesPendingUpgrade = downstreamPackageSummaries.filter(

--- a/plugins/cad/src/components/PackageRevisionPage/components/AdvancedPackageRevisionOptions.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/AdvancedPackageRevisionOptions.tsx
@@ -16,12 +16,18 @@
 
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 import { Button } from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
 import React, { Fragment, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { configAsDataApiRef } from '../../../apis';
 import { repositoryRouteRef } from '../../../routes';
 import { Repository } from '../../../types/Repository';
 import { RootSync } from '../../../types/RootSync';
+import {
+  getPackageDescriptor,
+  isReadOnlyRepository,
+} from '../../../utils/repository';
+import { toLowerCase } from '../../../utils/string';
 import { ConfirmationDialog } from '../../Controls/ConfirmationDialog';
 
 type AdvancedPackageRevisionOptionsProps = {
@@ -85,6 +91,15 @@ export const AdvancedPackageRevisionOptions = ({
 
     navigate(repositoryRef({ repositoryName }));
   };
+
+  if (isReadOnlyRepository(repository)) {
+    return (
+      <Alert severity="info">
+        Advanced options are hidden since this{' '}
+        {toLowerCase(getPackageDescriptor(repository))} is read-only.
+      </Alert>
+    );
+  }
 
   return (
     <Fragment>

--- a/plugins/cad/src/components/RegisterRepositoryPage/RegisterRepositoryPage.tsx
+++ b/plugins/cad/src/components/RegisterRepositoryPage/RegisterRepositoryPage.tsx
@@ -47,6 +47,7 @@ import {
   getRepositoryResource,
   getSecretRef,
   PackageContentSummaryOrder,
+  RepositoryAccess,
   RepositoryContentDetails,
 } from '../../utils/repository';
 import { getBasicAuthSecret, isBasicAuthSecret } from '../../utils/secret';
@@ -86,7 +87,8 @@ export const RegisterRepositoryPage = () => {
     description: '',
     repoBranch: '',
     repoDir: '',
-    authType: '',
+    authType: AuthenticationType.GITHUB_ACCESS_TOKEN,
+    repositoryAccess: RepositoryAccess.FULL,
     useSecret: 'new',
     authSecretName: '',
     authPassword: '',
@@ -155,6 +157,7 @@ export const RegisterRepositoryPage = () => {
     }
 
     const contentSummary = state.contentSummary as ContentSummary;
+    const repositoryAccess = state.repositoryAccess as RepositoryAccess;
 
     if (contentSummary === ContentSummary.DEPLOYMENT) {
       deploymentEnvironment =
@@ -165,6 +168,7 @@ export const RegisterRepositoryPage = () => {
       state.name,
       state.description,
       contentSummary,
+      repositoryAccess,
       gitDetails,
       ociDetails,
       deploymentEnvironment,
@@ -384,7 +388,9 @@ export const RegisterRepositoryPage = () => {
           <div className={classes.stepContent}>
             <Select
               label="Authentication Type"
-              onChange={value => setState({ ...state, authType: value })}
+              onChange={value =>
+                setState({ ...state, authType: value as AuthenticationType })
+              }
               selected={state.authType}
               items={selectAuthTypeItems}
               helperText="The authentication type of the repository. Select None if the repository does not require any authentication."
@@ -432,6 +438,28 @@ export const RegisterRepositoryPage = () => {
                   />
                 </Fragment>
               )}
+
+            <Select
+              label="Repository Access"
+              onChange={value =>
+                setState({
+                  ...state,
+                  repositoryAccess: value as RepositoryAccess,
+                })
+              }
+              selected={state.repositoryAccess}
+              items={[
+                {
+                  value: RepositoryAccess.FULL,
+                  label: 'Write access',
+                },
+                {
+                  value: RepositoryAccess.READ_ONLY,
+                  label: 'Read-only access',
+                },
+              ]}
+              helperText="The access anyone using the UI will have to the repository. Write access allows packages to be created and updated in the repository, whereas read-only access allows packages to be viewed. Select read-only access if the repository authentication only allows read access."
+            />
           </div>
         </SimpleStepperStep>
 

--- a/plugins/cad/src/components/RepositoryPage/RepositoryPage.tsx
+++ b/plugins/cad/src/components/RepositoryPage/RepositoryPage.tsx
@@ -45,6 +45,7 @@ import {
   isDeploymentRepository,
   isFunctionRepository,
   isPackageRepository,
+  isReadOnlyRepository,
 } from '../../utils/repository';
 import {
   getRepositorySummaries,
@@ -167,6 +168,7 @@ export const RepositoryPage = () => {
 
   const thisRepository = repositorySummary.repository;
   const repoTitle = getRepositoryTitle(thisRepository);
+  const isReadOnly = isReadOnlyRepository(thisRepository);
 
   const packageDescriptor = getPackageDescriptor(thisRepository);
 
@@ -178,13 +180,15 @@ export const RepositoryPage = () => {
       </Breadcrumbs>
 
       <ContentHeader title={repoTitle}>
-        <Button
-          to={addPackageRef({ repositoryName: repositoryName })}
-          color="primary"
-          variant="contained"
-        >
-          Add {packageDescriptor}
-        </Button>
+        {!isReadOnly && (
+          <Button
+            to={addPackageRef({ repositoryName: repositoryName })}
+            color="primary"
+            variant="contained"
+          >
+            Add {packageDescriptor}
+          </Button>
+        )}
       </ContentHeader>
 
       <Tabs

--- a/plugins/cad/src/components/RepositoryPage/components/PackagesTabContent.tsx
+++ b/plugins/cad/src/components/RepositoryPage/components/PackagesTabContent.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { makeStyles } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
 import React, { Fragment } from 'react';
 import { Function } from '../../../types/Function';
@@ -24,7 +25,9 @@ import {
   isDeploymentRepository,
   isFunctionRepository,
   isPackageRepository,
+  isReadOnlyRepository,
 } from '../../../utils/repository';
+import { toLowerCase } from '../../../utils/string';
 import { PackagesTable } from '../../PackagesTable';
 import { FunctionsTable } from '../components/FunctionsTable';
 
@@ -35,13 +38,22 @@ type PackagesTabContentProps = {
   packagesError?: Error;
 };
 
+const useStyles = makeStyles({
+  messageBanner: {
+    marginBottom: '16px',
+  },
+});
+
 export const PackagesTabContent = ({
   repository,
   packages,
   functions,
   packagesError,
 }: PackagesTabContentProps) => {
+  const classes = useStyles();
+
   const pluralPackageDescriptor = `${getPackageDescriptor(repository)}s`;
+  const isReadOnly = isReadOnlyRepository(repository);
 
   if (packagesError) {
     return <Alert severity="error">{packagesError.message}</Alert>;
@@ -49,6 +61,14 @@ export const PackagesTabContent = ({
 
   return (
     <Fragment>
+      {isReadOnly && (
+        <Alert className={classes.messageBanner} severity="info">
+          This repository is read-only. You will not be able to add or make any
+          changes to the {toLowerCase(pluralPackageDescriptor)} in this
+          repository.
+        </Alert>
+      )}
+
       {isPackageRepository(repository) && (
         <PackagesTable
           title={pluralPackageDescriptor}

--- a/plugins/cad/src/components/RepositoryPage/components/RepositoryDetails.tsx
+++ b/plugins/cad/src/components/RepositoryPage/components/RepositoryDetails.tsx
@@ -22,6 +22,7 @@ import {
   getDeploymentEnvironment,
   getPackageDescriptor,
   isDeploymentRepository,
+  isReadOnlyRepository,
 } from '../../../utils/repository';
 
 type RepositoryDetailsProps = {
@@ -83,11 +84,14 @@ const getRepositoryStatusConditions = (repository: Repository): Metadata => {
 };
 
 const getRepositoryMetadata = (repository: Repository): Metadata => {
+  const isReadOnly = isReadOnlyRepository(repository);
+
   const metadata: Metadata = {
     name: repository.metadata.name,
     description: repository.spec.description ?? '',
     content: `${getPackageDescriptor(repository)}s`,
     deploymentEnvironment: getDeploymentEnvironment(repository),
+    repositoryAccess: isReadOnly ? 'read-only access' : 'write access',
     ...getRepositoryStoreMetadata(repository),
     ...getRepositoryStatusConditions(repository),
   };

--- a/plugins/cad/src/utils/repository.ts
+++ b/plugins/cad/src/utils/repository.ts
@@ -58,6 +58,7 @@ type EnvironmentDetail = {
 const REPOSITORY_CONTENT_LABEL = 'kpt.dev/repository-content';
 const REPOSITORY_DEPLOYMENT_ENVIRONMENT_LABEL =
   'kpt.dev/deployment-environment';
+const REPOSITORY_ACCESS_LABEL = 'kpt.dev/repository-access';
 
 export enum ContentSummary {
   EXTERNAL_BLUEPRINT = 'External Blueprint',
@@ -71,6 +72,11 @@ export enum DeploymentEnvironment {
   DEVELOPMENT = 'Development',
   STAGING = 'Staging',
   PRODUCTION = 'Production',
+}
+
+export enum RepositoryAccess {
+  FULL = 'full',
+  READ_ONLY = 'read-only',
 }
 
 export const PackageContentSummaryOrder = [
@@ -222,6 +228,14 @@ const normalizeRepositoryUrl = (repositoryUrl?: string): string => {
   return thisRepositoryUrl;
 };
 
+export const isReadOnlyRepository = (repository: Repository): boolean => {
+  const isReadOnly =
+    repository.metadata.labels?.[REPOSITORY_ACCESS_LABEL] ===
+    RepositoryAccess.READ_ONLY;
+
+  return isReadOnly;
+};
+
 export const getPackageDescriptor = (repository: Repository): string => {
   for (const contentType of Object.keys(RepositoryContentDetails)) {
     if (isRepositoryContent(repository, contentType as ContentSummary)) {
@@ -301,6 +315,7 @@ export const getRepositoryResource = (
   name: string,
   description: string,
   contentSummary: ContentSummary,
+  repositoryAccess: RepositoryAccess,
   git?: RepositoryGitDetails,
   oci?: RepositoryOciDetails,
   deploymentEnvironment?: DeploymentEnvironment,
@@ -327,6 +342,10 @@ export const getRepositoryResource = (
       labels[REPOSITORY_DEPLOYMENT_ENVIRONMENT_LABEL] =
         environmentDetails.repositoryEnvironmentLabelValue;
     }
+  }
+
+  if (repositoryAccess === RepositoryAccess.READ_ONLY) {
+    labels[REPOSITORY_ACCESS_LABEL] = RepositoryAccess.READ_ONLY;
   }
 
   const resource: Repository = {


### PR DESCRIPTION
This change updates the Register Repository Page to request if the repository has read-only access when a repository is being registered. If a repository is read-only, the UI will hide any options to add or update packages in the repository.