### PR TITLE
feat: allow git ops tool to be configurable

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -77,6 +77,9 @@ configAsData:
   # The namespace where Porch managed resources live.
   resourcesNamespace: default
 
+  # Determines the GitOps delivery tool to use.
+  gitOpsDeliveryTool: config-sync
+
   clusterLocatorMethod:
     # Determines how the client will locate the Kubernetes cluster.
     type: current-context

--- a/plugins/cad-backend/README.md
+++ b/plugins/cad-backend/README.md
@@ -56,6 +56,9 @@ configAsData:
   # The namespace where Porch managed resources live.
   resourcesNamespace: default
 
+  # Determines the GitOps delivery tool to use.
+  gitOpsDeliveryTool: config-sync
+
   clusterLocatorMethod:
     # Determines how the client will locate the Kubernetes cluster.
     type: current-context
@@ -71,6 +74,14 @@ configAsData:
 ```
 
 `resourcesNamespace` defines the namespace where Porch managed resources live
+
+`gitOpsDeliveryTool` determines what tool to use for GitOps
+
+Valid values:
+| Values | Description |
+| ------ | ----------- |
+| none | Use no GitOps delivery tool |
+| config-sync | Use [Config Sync](https://github.com/GoogleContainerTools/kpt-config-sync). Config Sync must be installed on the cluster. |
 
 `clusterLocatorMethod` determines where to receive the cluster configuration
 from

--- a/plugins/cad-backend/src/service/config.ts
+++ b/plugins/cad-backend/src/service/config.ts
@@ -16,6 +16,11 @@
 
 import { Config } from '@backstage/config';
 
+export enum GitOpsDeliveryTool {
+  NONE = 'none',
+  CONFIG_SYNC = 'config-sync',
+}
+
 export enum ClusterLocatorMethodType {
   CURRENT_CONTEXT = 'current-context',
   IN_CLUSTER = 'in-cluster',
@@ -38,6 +43,16 @@ export const getResourcesNamespace = (config: Config): string => {
   const namespace = config.getString('resourcesNamespace');
 
   return namespace;
+};
+
+export const getGitOpsDeliveryTool = (config: Config): GitOpsDeliveryTool => {
+  const gitOpsTool = config.getString('gitOpsDeliveryTool');
+
+  if (!Object.values(GitOpsDeliveryTool)) {
+    throw new Error(`Unknown gitOpsDeliveryTool, ${gitOpsTool}`);
+  }
+
+  return gitOpsTool as GitOpsDeliveryTool;
 };
 
 export const getClusterLocatorMethodType = (

--- a/plugins/cad-backend/src/service/router.ts
+++ b/plugins/cad-backend/src/service/router.ts
@@ -26,6 +26,7 @@ import {
   getClusterLocatorMethodOIDCTokenProvider,
   getClusterLocatorMethodServiceAccountToken,
   getClusterLocatorMethodType,
+  getGitOpsDeliveryTool,
   getResourcesNamespace,
   OIDCTokenProvider,
 } from './config';
@@ -79,6 +80,8 @@ export async function createRouter({
   const cadConfig = config.getConfig('configAsData');
 
   const namespace = getResourcesNamespace(cadConfig);
+  const gitOpsTool = getGitOpsDeliveryTool(cadConfig);
+
   const clusterLocatorMethodType = getClusterLocatorMethodType(cadConfig);
   const clusterLocatorMethodAuthProvider =
     getClusterLocatorMethodAuthProvider(cadConfig);
@@ -118,6 +121,7 @@ export async function createRouter({
     response.send({
       authentication: clientAuthentication,
       namespace: namespace,
+      gitOps: gitOpsTool,
     });
   };
 

--- a/plugins/cad/src/apis/ConfigAsDataApi.ts
+++ b/plugins/cad/src/apis/ConfigAsDataApi.ts
@@ -17,6 +17,7 @@
 import { createApiRef } from '@backstage/core-plugin-api';
 import { ListApiGroups } from '../types/ApiGroup';
 import { ListConfigManagements } from '../types/ConfigManagement';
+import { GetFeaturesResponse } from '../types/Features';
 import { Function } from '../types/Function';
 import { PackageRevision } from '../types/PackageRevision';
 import {
@@ -28,7 +29,7 @@ import { ListRootSyncs, RootSync } from '../types/RootSync';
 import { ListSecrets, Secret } from '../types/Secret';
 
 export type ConfigAsDataApi = {
-  getFeatures(): Promise<void>;
+  getFeatures(): Promise<GetFeaturesResponse>;
 
   listApiGroups(): Promise<ListApiGroups>;
 

--- a/plugins/cad/src/apis/PorchRestApi.ts
+++ b/plugins/cad/src/apis/PorchRestApi.ts
@@ -23,6 +23,7 @@ import {
 import { ConfigAsDataApi } from '.';
 import { ListApiGroups } from '../types/ApiGroup';
 import { ListConfigManagements } from '../types/ConfigManagement';
+import { GetFeaturesResponse } from '../types/Features';
 import { Function } from '../types/Function';
 import { KubernetesStatus } from '../types/KubernetesStatus';
 import { PackageRevision } from '../types/PackageRevision';
@@ -162,7 +163,7 @@ export class PorchRestAPI implements ConfigAsDataApi {
     return await response.json();
   }
 
-  async getFeatures(): Promise<void> {
+  async getFeatures(): Promise<GetFeaturesResponse> {
     const features = await this.cadFetch('v1/features');
 
     this.authentication = features.authentication;
@@ -173,6 +174,8 @@ export class PorchRestAPI implements ConfigAsDataApi {
         'The Configuration as Data backend is not returning all expected features. Pleae update the Backstage Configuration as Data Plugins to the latest version.',
       );
     }
+
+    return features;
   }
 
   async listApiGroups(): Promise<ListApiGroups> {

--- a/plugins/cad/src/types/Features.ts
+++ b/plugins/cad/src/types/Features.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type GetFeaturesResponse = {
+  authentication: string;
+  namespace: string;
+  gitOps: string;
+};

--- a/plugins/cad/src/utils/featureFlags.ts
+++ b/plugins/cad/src/utils/featureFlags.ts
@@ -16,26 +16,28 @@
 
 import { ConfigAsDataApi } from '../apis';
 
-let isConfigSyncInstalled = false;
+let configSyncEnabled = false;
 
-export const isConfigSyncEnabled = (): boolean => isConfigSyncInstalled;
+export const isConfigSyncEnabled = (): boolean => configSyncEnabled;
 
 export const allowFunctionRepositoryRegistration = (): boolean => false;
 
 export const showRegisteredFunctionRepositories = (): boolean => false;
 
 export const loadFeatures = async (api: ConfigAsDataApi): Promise<void> => {
-  await api.getFeatures();
+  const features = await api.getFeatures();
 
-  const { groups } = await api.listApiGroups();
+  if (features.gitOps === 'config-sync') {
+    const { groups } = await api.listApiGroups();
 
-  const configManagementGroupExists = !!groups.find(
-    apiGroup => apiGroup.name === 'configmanagement.gke.io',
-  );
+    const configManagementGroupExists = !!groups.find(
+      apiGroup => apiGroup.name === 'configmanagement.gke.io',
+    );
 
-  if (configManagementGroupExists) {
-    const { items: configManagements } = await api.listConfigManagements();
+    if (configManagementGroupExists) {
+      const { items: configManagements } = await api.listConfigManagements();
 
-    isConfigSyncInstalled = configManagements.length > 0;
+      configSyncEnabled = configManagements.length > 0;
+    }
   }
 };


### PR DESCRIPTION
This change updates the GitOps delivery tool to be configurable instead of always defaulting to Config Sync.