### PR TITLE
feat: allow filtering of packages

### DIFF
--- a/plugins/cad/src/components/Controls/Chip.tsx
+++ b/plugins/cad/src/components/Controls/Chip.tsx
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Chip as MaterialChip, makeStyles } from '@material-ui/core';
+import React from 'react';
+
+type ChipProps = {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+};
+
+const useStyles = makeStyles({
+  chip: {
+    marginBottom: 0,
+    transitionDuration: '0s !important',
+    '& > span': {
+      fontWeight: 'normal',
+    },
+  },
+});
+
+export const Chip = ({ label, selected, onClick }: ChipProps) => {
+  const classes = useStyles();
+
+  return (
+    <MaterialChip
+      className={classes.chip}
+      label={label}
+      color={selected ? 'primary' : undefined}
+      variant={selected ? undefined : 'outlined'}
+      onClick={onClick}
+    />
+  );
+};

--- a/plugins/cad/src/components/Controls/index.ts
+++ b/plugins/cad/src/components/Controls/index.ts
@@ -17,6 +17,7 @@
 export { Autocomplete } from './Autocomplete';
 export { ConfirmationDialog } from './ConfirmationDialog';
 export { Checkbox } from './Checkbox';
+export { Chip } from './Chip';
 export { IconButton } from './IconButton';
 export { MultiSelect } from './MultiSelect';
 export { PackageIcon } from './PackageIcon';

--- a/plugins/cad/src/components/PackageManagementPage/components/ContentInfoCard.tsx
+++ b/plugins/cad/src/components/PackageManagementPage/components/ContentInfoCard.tsx
@@ -20,9 +20,11 @@ import { makeStyles } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import React, { Fragment } from 'react';
 import { packagesRouteRef } from '../../../routes';
-import { PackageRevisionLifecycle } from '../../../types/PackageRevision';
 import { Repository } from '../../../types/Repository';
-import { PackageSummary } from '../../../utils/packageSummary';
+import {
+  filterPackageSummaries,
+  PackageSummary,
+} from '../../../utils/packageSummary';
 import {
   isRepositoryReady,
   RepositoryContentDetails,
@@ -71,29 +73,6 @@ const getActions = (
   );
 };
 
-const getPublishedPackages = (packages: PackageSummary[]): PackageSummary[] => {
-  return packages.filter(summary => !!summary.latestPublishedRevision);
-};
-
-const getProposedPackages = (packages: PackageSummary[]): PackageSummary[] => {
-  return packages.filter(
-    summary =>
-      summary.latestRevision.spec.lifecycle ===
-      PackageRevisionLifecycle.PROPOSED,
-  );
-};
-
-const getDraftPackages = (packages: PackageSummary[]): PackageSummary[] => {
-  return packages.filter(
-    summary =>
-      summary.latestRevision.spec.lifecycle === PackageRevisionLifecycle.DRAFT,
-  );
-};
-
-const getUpgradePackages = (packages: PackageSummary[]): PackageSummary[] => {
-  return packages.filter(summary => summary.isUpgradeAvailable);
-};
-
 export const ContentInfoCard = ({
   contentType,
   repositories,
@@ -109,10 +88,12 @@ export const ContentInfoCard = ({
     repository => !isRepositoryReady(repository),
   );
 
-  const published = getPublishedPackages(packages).length;
-  const upgradesAvailable = getUpgradePackages(packages).length;
-  const pendingReview = getDraftPackages(packages).length;
-  const drafts = getProposedPackages(packages).length;
+  const published = filterPackageSummaries(packages, { isPublished: true });
+  const upgradesAvailable = filterPackageSummaries(packages, {
+    isUpgradeAvailable: true,
+  });
+  const pendingReview = filterPackageSummaries(packages, { isProposed: true });
+  const drafts = filterPackageSummaries(packages, { isDraft: true });
 
   const subheader = `${repositories.length} repositories registered`;
 
@@ -137,7 +118,7 @@ export const ContentInfoCard = ({
 
         {repositories.length > 0 && (
           <Alert severity="success">
-            {published} {contentTypeLowerCase}s published
+            {published.length} {contentTypeLowerCase}s published
           </Alert>
         )}
 
@@ -147,19 +128,23 @@ export const ContentInfoCard = ({
           </Alert>
         ))}
 
-        {upgradesAvailable > 0 && (
+        {upgradesAvailable.length > 0 && (
           <Alert severity="info">
-            {upgradesAvailable} {contentTypeLowerCase}s with upgrades available
+            {upgradesAvailable.length} {contentTypeLowerCase}s with upgrades
+            available
           </Alert>
         )}
 
-        {pendingReview > 0 && (
+        {pendingReview.length > 0 && (
           <Alert severity="info">
-            {pendingReview} {contentTypeLowerCase} revisions pending review
+            {pendingReview.length} {contentTypeLowerCase} revisions pending
+            review
           </Alert>
         )}
 
-        {drafts > 0 && <Alert severity="info">{drafts} draft revisions</Alert>}
+        {drafts.length > 0 && (
+          <Alert severity="info">{drafts.length} draft revisions</Alert>
+        )}
       </div>
     </InfoCard>
   );


### PR DESCRIPTION
This change updates the Packages Page and Repository Page to allow filters to be applied to the Packages Table so only draft, proposed, published, and upgrade available packages are shown.