### PR TITLE
fix: automatically update sync when new revision is published

### DIFF
--- a/plugins/cad/src/components/PackageRevisionPage/PackageRevisionPage.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/PackageRevisionPage.tsx
@@ -562,10 +562,10 @@ export const PackageRevisionPage = ({ mode }: PackageRevisionPageProps) => {
       const targetRevision = cloneDeep(packageRevision);
       targetRevision.spec.lifecycle = PackageRevisionLifecycle.PUBLISHED;
 
-      await api.approvePackageRevision(targetRevision);
+      const approvedRevision = await api.approvePackageRevision(targetRevision);
 
       if (isDeploymentPackage && configSyncEnabled) {
-        await updateRootSyncToLatestPackage(targetRevision);
+        await updateRootSyncToLatestPackage(approvedRevision);
       }
 
       await loadPackageRevision();

--- a/plugins/cad/src/utils/configSync.ts
+++ b/plugins/cad/src/utils/configSync.ts
@@ -46,8 +46,16 @@ export const getRootSync = (
   packageRevision: PackageRevision,
   secretName?: string,
 ): RootSync => {
-  const syncName = packageRevision.spec.packageName;
+  const { packageName, revision } = packageRevision.spec;
+
+  const syncName = packageName;
   const gitRepository = repository.spec.git;
+
+  if (!revision) {
+    throw new Error(
+      'RootSyncs can only be generated for packages with a revision',
+    );
+  }
 
   if (!gitRepository) {
     throw new Error('RootSyncs can only be generated for git repositories');
@@ -64,8 +72,8 @@ export const getRootSync = (
       sourceFormat: 'unstructured',
       git: {
         repo: gitRepository.repo,
-        revision: `${packageRevision.spec.packageName}/${packageRevision.spec.revision}`,
-        dir: packageRevision.spec.packageName,
+        revision: `${packageName}/${revision}`,
+        dir: packageName,
         branch: gitRepository.branch,
       },
     },


### PR DESCRIPTION
This change ensures a sync (if one is already created for the package) is automatically updated to use the latest published revision of a package when a new revision is published through the UI.