### PR TITLE
feat: show register repository link on landing page content cards

### DIFF
--- a/plugins/cad/src/components/Links/RegisterRepositoryLink.tsx
+++ b/plugins/cad/src/components/Links/RegisterRepositoryLink.tsx
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
-export { LandingPageLink } from './LandingPageLink';
-export { PackageLink } from './PackageLink';
-export { PackagesLink } from './PackagesLink';
-export { RegisterRepositoryLink } from './RegisterRepositoryLink';
-export { RepositoryLink } from './RepositoryLink';
+import { Link } from '@backstage/core-components';
+import { useRouteRef } from '@backstage/core-plugin-api';
+import React from 'react';
+import { registerRepositoryRouteRef } from '../../routes';
+
+export const RegisterRepositoryLink = () => {
+  const repositoryRef = useRouteRef(registerRepositoryRouteRef);
+
+  return <Link to={repositoryRef()}>Register Repository</Link>;
+};

--- a/plugins/cad/src/components/PackageManagementPage/components/ContentInfoCard.tsx
+++ b/plugins/cad/src/components/PackageManagementPage/components/ContentInfoCard.tsx
@@ -30,7 +30,7 @@ import {
   RepositoryContentDetails,
 } from '../../../utils/repository';
 import { toLowerCase } from '../../../utils/string';
-import { RepositoryLink } from '../../Links';
+import { RegisterRepositoryLink, RepositoryLink } from '../../Links';
 
 type ContentInfoCardProps = {
   contentType: string;
@@ -56,19 +56,23 @@ const getActions = (
   repositories: Repository[],
   className: string,
 ): JSX.Element => {
-  if (repositories.length === 0) {
-    return <Fragment />;
-  }
+  const anyRepositoriesRegistered = repositories.length > 0;
 
   return (
     <div className={className}>
-      <Fragment>Repositories:</Fragment>&nbsp;
-      {repositories.map((r, idx) => (
+      {!anyRepositoriesRegistered && <RegisterRepositoryLink />}
+
+      {anyRepositoriesRegistered && (
         <Fragment>
-          <RepositoryLink repository={r} />
-          {idx !== repositories.length - 1 && <Fragment>, </Fragment>}
+          <Fragment>Repositories:</Fragment>&nbsp;
+          {repositories.map((r, idx) => (
+            <Fragment key={r.metadata.name}>
+              <RepositoryLink repository={r} />
+              {idx !== repositories.length - 1 && <Fragment>, </Fragment>}
+            </Fragment>
+          ))}
         </Fragment>
-      ))}
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This change updates the Content Info Card to show a register repository link when there are no repositories registered for the content type.