### PR TITLE
feat: remove deployment environment from register repository page

### DIFF
--- a/plugins/cad/src/components/RegisterRepositoryPage/RegisterRepositoryPage.tsx
+++ b/plugins/cad/src/components/RegisterRepositoryPage/RegisterRepositoryPage.tsx
@@ -40,8 +40,6 @@ import { Secret } from '../../types/Secret';
 import { allowFunctionRepositoryRegistration } from '../../utils/featureFlags';
 import {
   ContentSummary,
-  DeploymentEnvironment,
-  DeploymentEnvironmentDetails,
   getRepositoryGitDetails,
   getRepositoryOciDetails,
   getRepositoryResource,
@@ -138,7 +136,6 @@ export const RegisterRepositoryPage = () => {
 
     let gitDetails: RepositoryGitDetails | undefined = undefined;
     let ociDetails: RepositoryOciDetails | undefined = undefined;
-    let deploymentEnvironment: DeploymentEnvironment | undefined = undefined;
 
     if (state.type === RepositoryType.GIT) {
       const createBranch = true;
@@ -159,11 +156,6 @@ export const RegisterRepositoryPage = () => {
     const contentSummary = state.contentSummary as ContentSummary;
     const repositoryAccess = state.repositoryAccess as RepositoryAccess;
 
-    if (contentSummary === ContentSummary.DEPLOYMENT) {
-      deploymentEnvironment =
-        state.deploymentEnvironment as DeploymentEnvironment;
-    }
-
     const resource = getRepositoryResource(
       state.name,
       state.description,
@@ -171,7 +163,6 @@ export const RegisterRepositoryPage = () => {
       repositoryAccess,
       gitDetails,
       ociDetails,
-      deploymentEnvironment,
     );
 
     return resource;
@@ -248,14 +239,6 @@ export const RegisterRepositoryPage = () => {
         }
       }
 
-      for (const [environment, details] of Object.entries(
-        DeploymentEnvironmentDetails,
-      )) {
-        if (repositoryUrl.includes(details.shortName)) {
-          toSet.deploymentEnvironment = environment;
-        }
-      }
-
       const suggestedName = kebabCase(
         repositoryUrl
           .split('/')
@@ -310,16 +293,6 @@ export const RegisterRepositoryPage = () => {
 
     return selectItems;
   }, []);
-
-  const deploymentEnvironmentRadioOptions = useMemo(
-    () =>
-      Object.keys(DeploymentEnvironmentDetails).map(env => ({
-        label: env,
-        value: env,
-        description: DeploymentEnvironmentDetails[env].description,
-      })),
-    [],
-  );
 
   return (
     <div>
@@ -497,22 +470,6 @@ export const RegisterRepositoryPage = () => {
             />
           </div>
         </SimpleStepperStep>
-
-        {state.contentSummary === ContentSummary.DEPLOYMENT && (
-          <SimpleStepperStep title="Deployment Environment">
-            <div className={classes.stepContent}>
-              <RadioGroup
-                label="Development Environment"
-                onChange={value =>
-                  updateStateValue('deploymentEnvironment', value)
-                }
-                value={state.deploymentEnvironment}
-                options={deploymentEnvironmentRadioOptions}
-                helperText="Select the environment that maps to your repository."
-              />
-            </div>
-          </SimpleStepperStep>
-        )}
 
         <SimpleStepperStep
           title="Confirm"

--- a/plugins/cad/src/components/RepositoryPage/components/RepositoryDetails.tsx
+++ b/plugins/cad/src/components/RepositoryPage/components/RepositoryDetails.tsx
@@ -19,9 +19,7 @@ import React from 'react';
 import { Repository } from '../../../types/Repository';
 import { RepositorySummary } from '../../../types/RepositorySummary';
 import {
-  getDeploymentEnvironment,
   getPackageDescriptor,
-  isDeploymentRepository,
   isReadOnlyRepository,
 } from '../../../utils/repository';
 
@@ -90,15 +88,10 @@ const getRepositoryMetadata = (repository: Repository): Metadata => {
     name: repository.metadata.name,
     description: repository.spec.description ?? '',
     content: `${getPackageDescriptor(repository)}s`,
-    deploymentEnvironment: getDeploymentEnvironment(repository),
     repositoryAccess: isReadOnly ? 'read-only access' : 'write access',
     ...getRepositoryStoreMetadata(repository),
     ...getRepositoryStatusConditions(repository),
   };
-
-  if (!isDeploymentRepository(repository)) {
-    delete metadata.deploymentEnvironment;
-  }
 
   return metadata;
 };


### PR DESCRIPTION
This change updates the Register Repository Page removing the deployment environment selection when the repository content type is set to deployments.