### PR TITLE
refactor: replace backstage button with link button

### DIFF
--- a/plugins/cad/src/components/PackageManagementPage/components/RepositoriesTabContent.tsx
+++ b/plugins/cad/src/components/PackageManagementPage/components/RepositoriesTabContent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Button } from '@backstage/core-components';
+import { LinkButton } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { makeStyles } from '@material-ui/core';
 import { groupBy } from 'lodash';
@@ -55,13 +55,13 @@ export const RepositoriesTabContent = ({
   return (
     <div className={classes.repositoriesTablesList}>
       <div style={{ textAlign: 'right' }}>
-        <Button
+        <LinkButton
           to={registerRepositoryRef()}
           color="primary"
           variant="contained"
         >
           Register Repository
-        </Button>
+        </LinkButton>
       </div>
 
       {PackageContentSummaryOrder.map(contentType => (

--- a/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionOptions.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/components/PackageRevisionOptions.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { Button } from '@backstage/core-components';
+import { LinkButton } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
-import { Button as MaterialButton } from '@material-ui/core';
+import { Button } from '@material-ui/core';
 import React, { Fragment } from 'react';
 import {
   clonePackageRouteRef,
@@ -87,46 +87,46 @@ const DraftPackageRevisionOptions = ({
   if (isEditMode) {
     return (
       <Fragment>
-        <Button
+        <LinkButton
           to={packageRef({ repositoryName, packageName })}
           variant="outlined"
           color="primary"
           disabled={disabled}
         >
           Cancel
-        </Button>
+        </LinkButton>
 
-        <MaterialButton
+        <Button
           onClick={() => onClick(RevisionOption.SAVE_REVISION)}
           variant="contained"
           color="primary"
           disabled={disabled}
         >
           Save
-        </MaterialButton>
+        </Button>
       </Fragment>
     );
   }
 
   return (
     <Fragment>
-      <Button
+      <LinkButton
         to={editPackageRef({ repositoryName, packageName })}
         color="primary"
         variant="outlined"
         disabled={disabled}
       >
         Edit
-      </Button>
+      </LinkButton>
 
-      <MaterialButton
+      <Button
         color="primary"
         variant="contained"
         onClick={() => onClick(RevisionOption.PROPOSE_REVISION)}
         disabled={disabled}
       >
         Propose
-      </MaterialButton>
+      </Button>
     </Fragment>
   );
 };
@@ -144,23 +144,23 @@ const ProposedPackageRevisionOptions = ({
 
   return (
     <Fragment>
-      <MaterialButton
+      <Button
         color="primary"
         variant="outlined"
         onClick={() => onClick(RevisionOption.REJECT_PROPOSED_REVISION)}
         disabled={disabled}
       >
         Reject
-      </MaterialButton>
+      </Button>
 
-      <MaterialButton
+      <Button
         color="primary"
         variant="contained"
         onClick={() => onClick(RevisionOption.APPROVE_PROPOSED_REVISION)}
         disabled={disabled}
       >
         Approve
-      </MaterialButton>
+      </Button>
     </Fragment>
   );
 };
@@ -195,17 +195,17 @@ const PublishedPackageRevisionOptions = ({
     return (
       <Fragment>
         {!isReadOnly && (
-          <MaterialButton
+          <Button
             onClick={() => onClick(RevisionOption.RESTORE_REVISION)}
             color="primary"
             variant="outlined"
             disabled={disabled}
           >
             Restore Revision
-          </MaterialButton>
+          </Button>
         )}
 
-        <Button
+        <LinkButton
           to={packageRef({
             repositoryName: latestPublishedRevision.spec.repository,
             packageName: latestPublishedRevision.metadata.name,
@@ -215,7 +215,7 @@ const PublishedPackageRevisionOptions = ({
           disabled={disabled}
         >
           View Latest Published Revision
-        </Button>
+        </LinkButton>
       </Fragment>
     );
   }
@@ -239,29 +239,29 @@ const PublishedPackageRevisionOptions = ({
   return (
     <Fragment>
       {showUpgrade && (
-        <MaterialButton
+        <Button
           variant="outlined"
           color="primary"
           onClick={() => onClick(RevisionOption.CREATE_UPGRADE_REVISION)}
           disabled={disabled}
         >
           Upgrade to Latest Blueprint
-        </MaterialButton>
+        </Button>
       )}
 
       {showCreateNewRevision && (
-        <MaterialButton
+        <Button
           variant="outlined"
           color="primary"
           onClick={() => onClick(RevisionOption.CREATE_NEW_REVISION)}
           disabled={disabled}
         >
           Create New Revision
-        </MaterialButton>
+        </Button>
       )}
 
       {isNewerUnpublishedRevision && (
-        <Button
+        <LinkButton
           to={packageRef({
             repositoryName,
             packageName: latestRevision.metadata.name,
@@ -270,29 +270,29 @@ const PublishedPackageRevisionOptions = ({
           variant="outlined"
         >
           View {latestRevision.spec.lifecycle} Revision
-        </Button>
+        </LinkButton>
       )}
 
       {showCreateSync && (
-        <MaterialButton
+        <Button
           color="primary"
           variant="contained"
           onClick={() => onClick(RevisionOption.CREATE_SYNC)}
           disabled={disabled}
         >
           Create Sync
-        </MaterialButton>
+        </Button>
       )}
 
       {showClone && (
-        <Button
+        <LinkButton
           to={clonePackageRef({ repositoryName, packageName })}
           color="primary"
           variant="contained"
           disabled={disabled}
         >
           Clone
-        </Button>
+        </LinkButton>
       )}
     </Fragment>
   );

--- a/plugins/cad/src/components/RepositoryPage/PackagesPage.tsx
+++ b/plugins/cad/src/components/RepositoryPage/PackagesPage.tsx
@@ -16,7 +16,7 @@
 
 import {
   Breadcrumbs,
-  Button,
+  LinkButton,
   ContentHeader,
   Progress,
   Tabs,
@@ -147,13 +147,13 @@ export const PackagesPage = () => {
 
       <ContentHeader title={pluralPackageDescriptor}>
         {showAddPackage && (
-          <Button
+          <LinkButton
             to={addPackageRef({ packageContent })}
             color="primary"
             variant="contained"
           >
             Add {packageDescriptor}
-          </Button>
+          </LinkButton>
         )}
       </ContentHeader>
 

--- a/plugins/cad/src/components/RepositoryPage/RepositoryPage.tsx
+++ b/plugins/cad/src/components/RepositoryPage/RepositoryPage.tsx
@@ -16,8 +16,8 @@
 
 import {
   Breadcrumbs,
-  Button,
   ContentHeader,
+  LinkButton,
   Progress,
   Tabs,
 } from '@backstage/core-components';
@@ -181,13 +181,13 @@ export const RepositoryPage = () => {
 
       <ContentHeader title={repoTitle}>
         {!isReadOnly && (
-          <Button
+          <LinkButton
             to={addPackageRef({ repositoryName: repositoryName })}
             color="primary"
             variant="contained"
           >
             Add {packageDescriptor}
-          </Button>
+          </LinkButton>
         )}
       </ContentHeader>
 


### PR DESCRIPTION
This change updates the UI to use the link button as the backstage button core component is now deprecated.