### PR TITLE
chore: update install porch script to avoid top level tar option

### DIFF
--- a/hack/install-porch.sh
+++ b/hack/install-porch.sh
@@ -34,7 +34,8 @@ PORCH_VERSION=`echo "$LATEST_PORCH_RELEASE" | cut -d/ -f 2`
 echo "Download Porch $PORCH_VERSION deployment blueprint"
 TMPDIR=`mktemp -d -t porch-XXXXXX`
 curl -Lso $TMPDIR/deployment-blueprint.tar.gz https://github.com/GoogleContainerTools/kpt/releases/download/$LATEST_PORCH_RELEASE/deployment-blueprint.tar.gz
-tar xzf $TMPDIR/deployment-blueprint.tar.gz --one-top-level=$TMPDIR/porch-install
+mkdir $TMPDIR/porch-install
+tar xzf $TMPDIR/deployment-blueprint.tar.gz -C $TMPDIR/porch-install
 
 CLUSTER_NAME=`kubectl config current-context`
 echo "Apply Porch resources to cluster $CLUSTER_NAME"


### PR DESCRIPTION
This change updates the `./install-porch.sh` script to avoid using the --one-top-level option with tar since this option isn't available in all distributions of tar.