### PR TITLE
fix: allow settings page to show without error

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,6 +13,7 @@
     "@backstage/core-components": "^0.12.5",
     "@backstage/core-plugin-api": "^1.5.0",
     "@backstage/integration-react": "^1.1.11",
+    "@backstage/plugin-catalog": "^1.9.0",
     "@backstage/plugin-permission-react": "^0.4.11",
     "@backstage/plugin-user-settings": "^0.7.1",
     "@backstage/theme": "^0.2.18",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -23,6 +23,7 @@ import { Root } from './components/Root';
 import { createApp } from '@backstage/app-defaults';
 import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
 import { AlertDisplay, OAuthRequestDialog } from '@backstage/core-components';
+import { CatalogEntityPage, CatalogIndexPage } from '@backstage/plugin-catalog';
 import { CadPage } from '@kpt/backstage-plugin-cad';
 
 const app = createApp({
@@ -32,6 +33,11 @@ const app = createApp({
 const routes = (
   <FlatRoutes>
     <Navigate key="/" to="config-as-data" />
+    <Route path="/catalog" element={<CatalogIndexPage />} />
+    <Route
+      path="/catalog/:namespace/:kind/:name"
+      element={<CatalogEntityPage />}
+    />
     <Route path="/settings" element={<UserSettingsPage />} />
     <Route path="/config-as-data" element={<CadPage />} />
   </FlatRoutes>

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -20,6 +20,7 @@
     "@backstage/config": "^1.0.7",
     "@backstage/plugin-app-backend": "^0.3.43",
     "@backstage/plugin-auth-backend": "^0.18.1",
+    "@backstage/plugin-catalog-backend": "^1.8.0",
     "@backstage/plugin-permission-common": "^0.7.4",
     "@backstage/plugin-permission-node": "^0.7.6",
     "@backstage/plugin-proxy-backend": "^0.2.37",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -33,6 +33,7 @@ import Router from 'express-promise-router';
 import app from './plugins/app';
 import auth from './plugins/auth';
 import cad from './plugins/cad';
+import catalog from './plugins/catalog';
 import proxy from './plugins/proxy';
 import { PluginEnvironment } from './types';
 
@@ -79,12 +80,14 @@ async function main() {
 
   const cadEnv = useHotMemoize(module, () => createEnv('cad'));
   const authEnv = useHotMemoize(module, () => createEnv('auth'));
+  const catalogEnv = useHotMemoize(module, () => createEnv('catalog'));
   const proxyEnv = useHotMemoize(module, () => createEnv('proxy'));
   const appEnv = useHotMemoize(module, () => createEnv('app'));
 
   const apiRouter = Router();
   apiRouter.use('/config-as-data', await cad(cadEnv));
   apiRouter.use('/auth', await auth(authEnv));
+  apiRouter.use('/catalog', await catalog(catalogEnv));
   apiRouter.use('/proxy', await proxy(proxyEnv));
 
   // Add backends ABOVE this line; this 404 handler is the catch-all fallback

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -1,0 +1,12 @@
+import { CatalogBuilder } from '@backstage/plugin-catalog-backend';
+import { Router } from 'express';
+import { PluginEnvironment } from '../types';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  const builder = await CatalogBuilder.create(env);
+  const { processingEngine, router } = await builder.build();
+  await processingEngine.start();
+  return router;
+}

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { CatalogBuilder } from '@backstage/plugin-catalog-backend';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2576,6 +2576,48 @@
     node-fetch "^2.6.7"
     winston "^3.2.1"
 
+"@backstage/plugin-catalog-backend@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-backend/-/plugin-catalog-backend-1.8.0.tgz#ad4c08a5aa667573d680594cf85744c6fd46bdb9"
+  integrity sha512-bNqO4c2251O09vbMOHWHiWRk+S77BcBte7XeyUe0VVZv+Qomk1AvhQfHYpGnreadC3JTo3wuj6nk49XUxacD8g==
+  dependencies:
+    "@backstage/backend-common" "^0.18.3"
+    "@backstage/backend-plugin-api" "^0.5.0"
+    "@backstage/catalog-client" "^1.4.0"
+    "@backstage/catalog-model" "^1.2.1"
+    "@backstage/config" "^1.0.7"
+    "@backstage/errors" "^1.1.5"
+    "@backstage/integration" "^1.4.3"
+    "@backstage/plugin-catalog-common" "^1.0.12"
+    "@backstage/plugin-catalog-node" "^1.3.4"
+    "@backstage/plugin-permission-common" "^0.7.4"
+    "@backstage/plugin-permission-node" "^0.7.6"
+    "@backstage/plugin-scaffolder-common" "^1.2.6"
+    "@backstage/plugin-search-common" "^1.2.2"
+    "@backstage/types" "^1.0.2"
+    "@opentelemetry/api" "^1.3.0"
+    "@types/express" "^4.17.6"
+    codeowners-utils "^1.0.2"
+    core-js "^3.6.5"
+    express "^4.17.1"
+    express-promise-router "^4.1.0"
+    fast-json-stable-stringify "^2.1.0"
+    fs-extra "10.1.0"
+    git-url-parse "^13.0.0"
+    glob "^7.1.6"
+    knex "^2.0.0"
+    lodash "^4.17.21"
+    luxon "^3.0.0"
+    minimatch "^5.0.0"
+    node-fetch "^2.6.7"
+    p-limit "^3.0.2"
+    prom-client "^14.0.1"
+    uuid "^8.0.0"
+    winston "^3.2.1"
+    yaml "^2.0.0"
+    yn "^4.0.0"
+    zod "~3.18.0"
+
 "@backstage/plugin-catalog-common@^1.0.12":
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-common/-/plugin-catalog-common-1.0.12.tgz#5941088d730372ff9ca8938eff4fbfd7c6286a0f"
@@ -2584,6 +2626,18 @@
     "@backstage/catalog-model" "^1.2.1"
     "@backstage/plugin-permission-common" "^0.7.4"
     "@backstage/plugin-search-common" "^1.2.2"
+
+"@backstage/plugin-catalog-node@^1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-node/-/plugin-catalog-node-1.3.4.tgz#549e608fe46e461ebe982b8281b8304bfc239184"
+  integrity sha512-yrSAV17DZiHbnHPA6Ea7ZJiX4n9NwmjLlziMp2PK13fPifmIW5t4MmpPQ9IT+bUWGGYD2KRyW/LpItcVX5s2+g==
+  dependencies:
+    "@backstage/backend-plugin-api" "^0.5.0"
+    "@backstage/catalog-client" "^1.4.0"
+    "@backstage/catalog-model" "^1.2.1"
+    "@backstage/errors" "^1.1.5"
+    "@backstage/plugin-catalog-common" "^1.0.12"
+    "@backstage/types" "^1.0.2"
 
 "@backstage/plugin-catalog-react@^1.4.0":
   version "1.4.0"
@@ -2612,6 +2666,33 @@
     qs "^6.9.4"
     react-use "^17.2.4"
     yaml "^2.0.0"
+    zen-observable "^0.10.0"
+
+"@backstage/plugin-catalog@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog/-/plugin-catalog-1.9.0.tgz#3c94a7a23ddcfbb2ad366c38d78d27245c1f67cf"
+  integrity sha512-bmvciCtxES+BOeZgLFXkg/j0op3Rscf6+kfq9NoqgYw3RdAp8uk43LgApZxncOgwh/mgR5m0W/Eb4qPdGTM1og==
+  dependencies:
+    "@backstage/catalog-client" "^1.4.0"
+    "@backstage/catalog-model" "^1.2.1"
+    "@backstage/core-components" "^0.12.5"
+    "@backstage/core-plugin-api" "^1.5.0"
+    "@backstage/errors" "^1.1.5"
+    "@backstage/integration-react" "^1.1.11"
+    "@backstage/plugin-catalog-common" "^1.0.12"
+    "@backstage/plugin-catalog-react" "^1.4.0"
+    "@backstage/plugin-search-common" "^1.2.2"
+    "@backstage/plugin-search-react" "^1.5.1"
+    "@backstage/theme" "^0.2.18"
+    "@backstage/types" "^1.0.2"
+    "@material-ui/core" "^4.12.2"
+    "@material-ui/icons" "^4.9.1"
+    "@material-ui/lab" "4.0.0-alpha.57"
+    history "^5.0.0"
+    lodash "^4.17.21"
+    pluralize "^8.0.0"
+    react-helmet "6.1.0"
+    react-use "^17.2.4"
     zen-observable "^0.10.0"
 
 "@backstage/plugin-permission-common@^0.7.4":
@@ -2673,6 +2754,14 @@
     yn "^4.0.0"
     yup "^0.32.9"
 
+"@backstage/plugin-scaffolder-common@^1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-scaffolder-common/-/plugin-scaffolder-common-1.2.6.tgz#30714d31bbaf60bbebf6352c6be01e9206dd3776"
+  integrity sha512-quuPkh0Zxs6sD5/2/PzcylXe3UeEngxcc/xGHVn34y4t8j6bF1IsDeUPL4Om6cCLE6PdYw8rYEYL2P9vXherBw==
+  dependencies:
+    "@backstage/catalog-model" "^1.2.1"
+    "@backstage/types" "^1.0.2"
+
 "@backstage/plugin-search-common@^1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-search-common/-/plugin-search-common-1.2.2.tgz#cbb462d2a000086aa195be2c911acfdce30390e4"
@@ -2680,6 +2769,24 @@
   dependencies:
     "@backstage/plugin-permission-common" "^0.7.4"
     "@backstage/types" "^1.0.2"
+
+"@backstage/plugin-search-react@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-search-react/-/plugin-search-react-1.5.1.tgz#80ebd166efe589de513630c667cd8bb2ba172c39"
+  integrity sha512-kQyj/gDYImJ8BRhyA3/ZBKqkOuaBCercgpxS4mjhPDCsEFusOyYl7HBwirdIr2OcB1D9dowxdAC70wSjiypQdA==
+  dependencies:
+    "@backstage/core-components" "^0.12.5"
+    "@backstage/core-plugin-api" "^1.5.0"
+    "@backstage/plugin-search-common" "^1.2.2"
+    "@backstage/theme" "^0.2.18"
+    "@backstage/types" "^1.0.2"
+    "@backstage/version-bridge" "^1.0.3"
+    "@material-ui/core" "^4.12.2"
+    "@material-ui/icons" "^4.9.1"
+    "@material-ui/lab" "4.0.0-alpha.57"
+    lodash "^4.17.21"
+    qs "^6.9.4"
+    react-use "^17.3.2"
 
 "@backstage/plugin-user-settings@^0.7.1":
   version "0.7.1"
@@ -4790,6 +4897,11 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
+"@opentelemetry/api@^1.3.0":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.4.1.tgz#ff22eb2e5d476fbc2450a196e40dd243cc20c28f"
+  integrity sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==
+
 "@panva/asn1.js@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@panva/asn1.js/-/asn1.js-1.0.0.tgz#dd55ae7b8129e02049f009408b97c61ccf9032f6"
@@ -6514,6 +6626,7 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     "@backstage/core-components" "^0.12.5"
     "@backstage/core-plugin-api" "^1.5.0"
     "@backstage/integration-react" "^1.1.11"
+    "@backstage/plugin-catalog" "^1.9.0"
     "@backstage/plugin-permission-react" "^0.4.11"
     "@backstage/plugin-user-settings" "^0.7.1"
     "@backstage/theme" "^0.2.18"
@@ -6975,6 +7088,11 @@ bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
+
+bintrees@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
+  integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
 
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
@@ -7612,6 +7730,16 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==
 
+codeowners-utils@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/codeowners-utils/-/codeowners-utils-1.0.2.tgz#9d30148bf957c53d55f75df432cb1e3b4bc6ee28"
+  integrity sha512-4oLRCymV7azxGHMpM3F297D651VdwZa21hVfFCn/cOd8Fq8tFrpfpyRpSBQkaZCyFPkfOhEld9xceCF7btyiug==
+  dependencies:
+    cross-spawn "^7.0.2"
+    find-up "^4.1.0"
+    ignore "^5.1.4"
+    locate-path "^5.0.0"
+
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
@@ -8026,6 +8154,11 @@ core-js-pure@^3.23.3:
   version "3.28.0"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.28.0.tgz#4ef2888475b6c856ef6f5aeef8b4f618b76ad048"
   integrity sha512-DSOVleA9/v3LNj/vFxAPfUHttKTzrB2RXhAPvR5TPXn4vrra3Z2ssytvRyt8eruJwAfwAiFADEbrjcRdcvPLQQ==
+
+core-js@^3.6.5:
+  version "3.30.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.30.0.tgz#64ac6f83bc7a49fd42807327051701d4b1478dea"
+  integrity sha512-hQotSSARoNh1mYPi9O2YaWeiq/cEB95kOrFb4NCrO4RIFt1qqNpKsaE+vy/L3oiqvND5cThqXzUU3r9F7Efztg==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -15507,6 +15640,13 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
+prom-client@^14.0.1:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.2.0.tgz#ca94504e64156f6506574c25fb1c34df7812cf11"
+  integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
+  dependencies:
+    tdigest "^0.1.1"
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -17739,6 +17879,13 @@ tarn@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/tarn/-/tarn-3.0.2.tgz#73b6140fbb881b71559c4f8bfde3d9a4b3d27693"
   integrity sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==
+
+tdigest@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
+  integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
+  dependencies:
+    bintrees "1.0.2"
 
 teeny-request@^8.0.0:
   version "8.0.2"


### PR DESCRIPTION
This change allows the Settings page to show successfully by importing the Software Catalog. The Settings page was recently updated in Backstage to enable linking to the Software Catalog, thus requiring the plugin to be imported. 