### PR TITLE
fix: update resource viewer to handle null fields

### DIFF
--- a/plugins/cad/src/components/ResourceViewerDialog/components/FirstClassViewers/StructuredMetadata/StructuredMetadata.tsx
+++ b/plugins/cad/src/components/ResourceViewerDialog/components/FirstClassViewers/StructuredMetadata/StructuredMetadata.tsx
@@ -55,7 +55,11 @@ const useStyles = makeStyles({
 
 const normalizeMetadata = (metadata: Metadata): void => {
   Object.keys(metadata).forEach(key => {
-    if (metadata[key] === undefined || metadata[key] === '') {
+    if (
+      metadata[key] === undefined ||
+      metadata[key] === null ||
+      metadata[key] === ''
+    ) {
       delete metadata[key];
     }
 

--- a/plugins/cad/src/components/ResourceViewerDialog/components/FirstClassViewers/StructuredMetadata/resources/default.ts
+++ b/plugins/cad/src/components/ResourceViewerDialog/components/FirstClassViewers/StructuredMetadata/resources/default.ts
@@ -62,7 +62,7 @@ const populateMetadata = (
 ): void => {
   const STANDARD_K8S_FIELDS = ['apiVersion', 'kind', 'metadata'];
 
-  const firstLevelFields = Object.keys(object).filter(
+  const firstLevelFields = Object.keys(object || {}).filter(
     key => !STANDARD_K8S_FIELDS.includes(key) || depth !== 1,
   );
 


### PR DESCRIPTION
This change fixes an issue where the Resource Viewer Dialog crashes when the object to be displayed contains a field set to null.