### PR TITLE
feat: add support for porch resource version checks

### DIFF
--- a/plugins/cad/src/components/AddPackagePage/AddPackagePage.tsx
+++ b/plugins/cad/src/components/AddPackagePage/AddPackagePage.tsx
@@ -148,14 +148,16 @@ const mapRepositoryToSelectItem = (
 const getPackageResources = async (
   api: ConfigAsDataApi,
   packageName: string,
-): Promise<[PackageResource[], PackageRevisionResourcesMap]> => {
+): Promise<[PackageResource[], PackageRevisionResourcesMap, string]> => {
   const packageResourcesResponse = await api.getPackageRevisionResources(
     packageName,
   );
   const resourcesMap = packageResourcesResponse.spec.resources;
   const resources = getPackageResourcesFromResourcesMap(resourcesMap);
+  const resourceVersion =
+    packageResourcesResponse.metadata.resourceVersion || '';
 
-  return [resources, resourcesMap];
+  return [resources, resourcesMap, resourceVersion];
 };
 
 export const AddPackagePage = ({ action }: AddPackagePageProps) => {
@@ -464,7 +466,10 @@ export const AddPackagePage = ({ action }: AddPackagePageProps) => {
     const allKptFunctions = await api.listCatalogFunctions();
     const kptFunctions = groupFunctionsByName(allKptFunctions);
 
-    const [_, resourcesMap] = await getPackageResources(api, newPackageName);
+    const [_, resourcesMap, resourceVersion] = await getPackageResources(
+      api,
+      newPackageName,
+    );
 
     let updatedResourcesMap = resourcesMap;
 
@@ -484,6 +489,7 @@ export const AddPackagePage = ({ action }: AddPackagePageProps) => {
       const packageRevisionResources = getPackageRevisionResourcesResource(
         newPackageName,
         updatedResourcesMap,
+        resourceVersion,
       );
 
       await api.replacePackageRevisionResources(packageRevisionResources);

--- a/plugins/cad/src/components/PackageRevisionPage/PackageRevisionPage.tsx
+++ b/plugins/cad/src/components/PackageRevisionPage/PackageRevisionPage.tsx
@@ -261,6 +261,7 @@ export const PackageRevisionPage = ({ mode }: PackageRevisionPageProps) => {
   const [revisionSummaries, setRevisionSummaries] = useState<RevisionSummary[]>(
     [],
   );
+  const resourcesMapResourceVersion = useRef<string>('');
   const [resourcesMap, setResourcesMap] = useState<PackageRevisionResourcesMap>(
     {},
   );
@@ -339,6 +340,8 @@ export const PackageRevisionPage = ({ mode }: PackageRevisionPageProps) => {
     setRevisionSummaries(thisRevisionSummaries);
     setPackageRevision(thisPackageRevision);
     setResourcesMap(thisResources.spec.resources);
+    resourcesMapResourceVersion.current =
+      thisResources.metadata.resourceVersion || '';
 
     let upgradeAvailable = false;
     let thisUpstreamRepository: Repository | undefined = undefined;
@@ -665,6 +668,7 @@ export const PackageRevisionPage = ({ mode }: PackageRevisionPageProps) => {
         const packageRevisionResources = getPackageRevisionResourcesResource(
           thisPackageName,
           resourcesMap,
+          resourcesMapResourceVersion.current,
         );
 
         await api.replacePackageRevisionResources(packageRevisionResources);
@@ -741,6 +745,7 @@ export const PackageRevisionPage = ({ mode }: PackageRevisionPageProps) => {
     const packageRevisionResources = getPackageRevisionResourcesResource(
       packageName,
       resourcesMap,
+      resourcesMapResourceVersion.current,
     );
 
     const resourcesResponse = await api.replacePackageRevisionResources(

--- a/plugins/cad/src/types/PackageRevisionResource.ts
+++ b/plugins/cad/src/types/PackageRevisionResource.ts
@@ -31,6 +31,7 @@ export type PackageRevisionResources = {
 export type PackageRevisionResourcesMetadata = {
   name: string;
   namespace?: string;
+  resourceVersion?: string;
 };
 
 export type PackageRevisionResourcesSpec = {

--- a/plugins/cad/src/utils/packageRevisionResources.ts
+++ b/plugins/cad/src/utils/packageRevisionResources.ts
@@ -100,12 +100,14 @@ export const getPackageRevisionResources = (
 export const getPackageRevisionResourcesResource = (
   fullPackageName: string,
   resourcesMap: PackageRevisionResourcesMap,
+  resourceVersion: string,
 ): PackageRevisionResources => {
   const packageRevisionResources: PackageRevisionResources = {
     apiVersion: 'porch.kpt.dev/v1alpha1',
     kind: 'PackageRevisionResources',
     metadata: {
       name: fullPackageName,
+      resourceVersion: resourceVersion,
     },
     spec: {
       resources: resourcesMap,


### PR DESCRIPTION
This change updates the UI to support Porch optimistic concurrency control for package updates.